### PR TITLE
Fix #188 Modification de la sidebar du dashboard

### DIFF
--- a/frontend/src/components/DashboardSidebar.tsx
+++ b/frontend/src/components/DashboardSidebar.tsx
@@ -162,7 +162,6 @@ export default function DashboardSidebar() {
       children: [
         { key: "survey-all",  labelKey: "dashboardSidebar.survey.all",     to: "/admin/surveys",     roles: ["ADMIN", "MEMBER"] },
         { key: "survey-edit", labelKey: "dashboardSidebar.survey.newEdit", to: "/admin/surveys/new", roles: ["ADMIN", "MEMBER"] },
-        { key: "survey-show", labelKey: "dashboardSidebar.survey.show",    to: "/admin/surveys/show",roles: ["ADMIN", "MEMBER"] },
       ],
     },
     {
@@ -177,7 +176,6 @@ export default function DashboardSidebar() {
           children: [
             { key: "qps-all",  labelKey: "dashboardSidebar.qa.qps.all",     to: "/admin/qps",     roles: ["ADMIN", "MEMBER"] },
             { key: "qps-edit", labelKey: "dashboardSidebar.qa.qps.newEdit", to: "/admin/qps/new", roles: ["ADMIN", "MEMBER"] },
-            { key: "qps-show", labelKey: "dashboardSidebar.qa.qps.show",    to: "/admin/qps/show",roles: ["ADMIN", "MEMBER"] },
           ],
         },
         {
@@ -187,7 +185,6 @@ export default function DashboardSidebar() {
           children: [
             { key: "qglobal-all",  labelKey: "dashboardSidebar.qa.qglobal.all",     to: "/admin/qglobal",     roles: ["ADMIN", "MEMBER"] },
             { key: "qglobal-edit", labelKey: "dashboardSidebar.qa.qglobal.newEdit", to: "/admin/qglobal/new", roles: ["ADMIN", "MEMBER"] },
-            { key: "qglobal-show", labelKey: "dashboardSidebar.qa.qglobal.show",    to: "/admin/qglobal/show",roles: ["ADMIN", "MEMBER"] },
           ],
         },
         {
@@ -197,7 +194,6 @@ export default function DashboardSidebar() {
           children: [
             { key: "qcat-all",  labelKey: "dashboardSidebar.qa.qcat.all",     to: "/admin/qcat",     roles: ["ADMIN", "MEMBER"] },
             { key: "qcat-edit", labelKey: "dashboardSidebar.qa.qcat.newEdit", to: "/admin/qcat/new", roles: ["ADMIN", "MEMBER"] },
-            { key: "qcat-show", labelKey: "dashboardSidebar.qa.qcat.show",    to: "/admin/qcat/show",roles: ["ADMIN", "MEMBER"] },
           ],
         },
         {
@@ -207,7 +203,6 @@ export default function DashboardSidebar() {
           children: [
             { key: "answer-all",  labelKey: "dashboardSidebar.qa.answer.all",     to: "/admin/answers",     roles: ["ADMIN", "MEMBER"] },
             { key: "answer-edit", labelKey: "dashboardSidebar.qa.answer.newEdit", to: "/admin/answers/new", roles: ["ADMIN", "MEMBER"] },
-            { key: "answer-show", labelKey: "dashboardSidebar.qa.answer.show",    to: "/admin/answers/show",roles: ["ADMIN", "MEMBER"] },
           ],
         },
         {
@@ -217,7 +212,6 @@ export default function DashboardSidebar() {
           children: [
             { key: "option-all",  labelKey: "dashboardSidebar.qa.option.all",     to: "/admin/options",     roles: ["ADMIN", "MEMBER"] },
             { key: "option-edit", labelKey: "dashboardSidebar.qa.option.newEdit", to: "/admin/options/new", roles: ["ADMIN", "MEMBER"] },
-            { key: "option-show", labelKey: "dashboardSidebar.qa.option.show",    to: "/admin/options/show",roles: ["ADMIN", "MEMBER"] },
           ],
         },
       ],
@@ -233,7 +227,6 @@ export default function DashboardSidebar() {
           roles: ["ADMIN", "MEMBER"],
           children: [
             { key: "commune-all",  labelKey: "dashboardSidebar.places.commune.all",  to: "/admin/places/communes",       roles: ["ADMIN", "MEMBER"] },
-            { key: "commune-show", labelKey: "dashboardSidebar.places.commune.show", to: "/admin/places/communes/show",  roles: ["ADMIN", "MEMBER"] },
           ],
         },
         {
@@ -242,7 +235,6 @@ export default function DashboardSidebar() {
           roles: ["ADMIN", "MEMBER"],
           children: [
             { key: "district-all",  labelKey: "dashboardSidebar.places.district.all",  to: "/admin/places/districts",      roles: ["ADMIN", "MEMBER"] },
-            { key: "district-show", labelKey: "dashboardSidebar.places.district.show", to: "/admin/places/districts/show", roles: ["ADMIN", "MEMBER"] },
           ],
         },
         {
@@ -251,7 +243,6 @@ export default function DashboardSidebar() {
           roles: ["ADMIN", "MEMBER"],
           children: [
             { key: "canton-all",  labelKey: "dashboardSidebar.places.canton.all",  to: "/admin/places/cantons",      roles: ["ADMIN", "MEMBER"] },
-            { key: "canton-show", labelKey: "dashboardSidebar.places.canton.show", to: "/admin/places/cantons/show", roles: ["ADMIN", "MEMBER"] },
           ],
         },
       ],

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -339,62 +339,53 @@
       "dashboard": "Dashboard",
       "survey": "Survey",
       "qa": "Questions & Answers",
-      "places": "Places",
+      "places": "Lieux",
       "administration": "Administration"
     },
     "survey": {
       "_": "Survey",
       "all": "Tous",
-      "newEdit": "Nouveau / Éditer",
-      "show": "Afficher"
+      "newEdit": "Nouveau"
     },
     "qa": {
       "qps": {
         "_": "QuestionPerSurvey",
         "all": "Tous",
-        "newEdit": "Nouveau / Éditer",
-        "show": "Afficher"
+        "newEdit": "Nouveau"
       },
       "qglobal": {
         "_": "QuestionGlobal",
         "all": "Tous",
-        "newEdit": "Nouveau / Éditer",
-        "show": "Afficher"
+        "newEdit": "Nouveau"
       },
       "qcat": {
         "_": "QuestionCategory",
         "all": "Tous",
-        "newEdit": "Nouveau / Éditer",
-        "show": "Afficher"
+        "newEdit": "Nouveau"
       },
       "answer": {
         "_": "Answer",
         "all": "Tous",
-        "newEdit": "Nouveau / Éditer",
-        "show": "Afficher"
+        "newEdit": "Nouveau"
       },
       "option": {
         "_": "Option",
         "all": "Tous",
-        "newEdit": "Nouveau / Éditer",
-        "show": "Afficher"
+        "newEdit": "Nouveau"
       }
     },
     "places": {
       "commune": {
         "_": "Commune",
-        "all": "Toutes",
-        "show": "Afficher"
+        "all": "Tous"
       },
       "district": {
         "_": "District",
-        "all": "Tous",
-        "show": "Afficher"
+        "all": "Tous"
       },
       "canton": {
         "_": "Canton",
-        "all": "Tous",
-        "show": "Afficher"
+        "all": "Tous"
       }
     },
     "administration": {


### PR DESCRIPTION
- Modification de la sidebar du dashboard : 
  - suppression des éléments inutiles.
  - correction mots ex: Toutes -> tous
  - on garde soit Tous et Nouveau soit juste Tous

<img width="1444" height="716" alt="Capture d’écran 2026-01-21 à 17 48 38" src="https://github.com/user-attachments/assets/6e22460d-fbe8-478d-aeca-c154e04f24c0" />
