### PR TITLE
Fix #205 modification du user séparation du full_name en nom prénom

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -32,4 +32,5 @@ API_URL=http://$BACKEND_HOST:$BACKEND_PORT
 # Super admin instance account
 ROOT_EMAIL=admin@example.com
 ROOT_PASSWORD=very_secret_root_password
-ROOT_NAME='Admin Root'
+ROOT_FIRST_NAME=Admin
+ROOT_LAST_NAME=Root

--- a/backend/app/api/router/user.py
+++ b/backend/app/api/router/user.py
@@ -56,7 +56,8 @@ async def create_user(
     await create_user_record(
         db,
         email=payload.email,
-        full_name=payload.full_name,
+        first_name=payload.first_name,
+        last_name=payload.last_name,
         role=payload.role,
         password_hash=pwd_hash,
     )
@@ -95,7 +96,11 @@ async def delete_user(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
 
     # permet de normaliser la string pour comparer les informations
-    if normalize_name(target.full_name) != normalize_name(payload.full_name) or target.role != payload.role:
+    if (
+        normalize_name(target.first_name) != normalize_name(payload.first_name)
+        or normalize_name(target.last_name) != normalize_name(payload.last_name)
+        or target.role != payload.role
+    ):
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail="Les informations fournies ne correspondent pas à l'utilisateur",

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -52,7 +52,8 @@ class Settings(BaseSettings):
     # Super admin instance account
     ROOT_EMAIL: str | None = None
     ROOT_PASSWORD: str | None = None
-    ROOT_NAME: str | None = "Admin Root"
+    ROOT_FIRST_NAME: str | None = "Admin"
+    ROOT_LAST_NAME: str | None = "Root"
 
     model_config = SettingsConfigDict(
         env_file=".env", case_sensitive=False  # env_fill utile que en dev, case_sensitive passer a True en prod

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,13 +1,14 @@
 import uuid
 
 
-from sqlalchemy import Column, DateTime, Enum as SAEnum, String, Text
+from app.config.roles import Role, ROLE_VALUES
+from sqlalchemy import Column, DateTime
+from sqlalchemy import Enum as SAEnum
+from sqlalchemy import String, Text
 from sqlalchemy.sql import func
 
 
 from .base import Base
-from app.config.roles import ROLE_VALUES, Role
-
 
 
 class User(Base):
@@ -16,7 +17,8 @@ class User(Base):
     id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
     email = Column(String, unique=True, nullable=False, index=True)
     password_hash = Column(Text, nullable=False)
-    full_name = Column(String, nullable=False)
+    first_name = Column(String, nullable=False)
+    last_name = Column(String, nullable=False)
     role = Column(
         SAEnum(*ROLE_VALUES, name="user_role", native_enum=False),
         nullable=False,

--- a/backend/app/repositories/user_repo.py
+++ b/backend/app/repositories/user_repo.py
@@ -22,12 +22,15 @@ async def get_user_by_id(db: AsyncSession, id: str) -> Optional[User]:
     return res.scalars().first()
 
 
-async def create_user(db: AsyncSession, email: str, password: str, full_name: str, role: str = "MEMBER") -> User:
+async def create_user(
+    db: AsyncSession, email: str, password: str, first_name: str, last_name: str, role: str = "MEMBER"
+) -> User:
     """creates a user and updates the database."""
     user = User(
         email=email,
         password_hash=get_password_hash(password),
-        full_name=full_name,
+        first_name=first_name,
+        last_name=last_name,
         role=role,
     )
     db.add(user)
@@ -63,11 +66,14 @@ async def mark_token_created(db: AsyncSession, user_id: str) -> datetime:
     return issued_at
 
 
-async def create_user_record(db: AsyncSession, *, email: str, full_name: str, role: str, password_hash: str) -> User:
+async def create_user_record(
+    db: AsyncSession, *, email: str, first_name: str, last_name: str, role: str, password_hash: str
+) -> User:
     """Inserts a user and commit into the database."""
     user = User(
         email=email,
-        full_name=full_name,
+        first_name=first_name,
+        last_name=last_name,
         role=role,
         password_hash=password_hash,
     )

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -7,10 +7,9 @@ Conventions:
 from typing import Literal, Optional
 
 
-from app.schemas.validators import FullNameStr, PasswordStr
-from pydantic import BaseModel, ConfigDict, EmailStr, model_validator
 from app.config.roles import Role
-
+from app.schemas.validators import NameFirstStr, NameLastStr, PasswordStr
+from pydantic import BaseModel, ConfigDict, EmailStr, model_validator
 
 
 class UserCreate(BaseModel):
@@ -18,7 +17,8 @@ class UserCreate(BaseModel):
 
     email: EmailStr
     password: PasswordStr
-    full_name: FullNameStr
+    first_name: NameFirstStr
+    last_name: NameLastStr
     role: Role = Role.MEMBER
 
 
@@ -26,7 +26,8 @@ class UserBase(BaseModel):
     """Common user data (basis for other schemas)."""
 
     email: EmailStr
-    full_name: str
+    first_name: str
+    last_name: str
     role: str
 
 
@@ -34,13 +35,16 @@ class User(UserBase):
     """Representation of a read-side user (from the DB model)."""
 
     model_config = ConfigDict(from_attributes=True)
-
+    first_name: str
+    last_name: str
     role: Role  # ADMIN | MEMBER ...
 
 
 class UserPublic(BaseModel):
     """Minimum public view of a user (restricted exposure for frontend)."""
 
+    first_name: str
+    last_name: str
     role: Role
 
 
@@ -48,7 +52,8 @@ class UserDeleteIn(BaseModel):
     """Payload to request the deletion of a user (API entry)."""
 
     email: EmailStr
-    full_name: FullNameStr
+    first_name: NameFirstStr
+    last_name: NameLastStr
     role: Literal["ADMIN", "MEMBER"]
 
 

--- a/backend/app/schemas/validators.py
+++ b/backend/app/schemas/validators.py
@@ -9,13 +9,28 @@ from pydantic import AfterValidator
 _NAME_RE = re.compile(r"^[A-Za-zÀ-ÖØ-öø-ÿ0-9 .,'\-]+$")
 
 
-def _validate_full_name(v: str) -> str:
-    v = " ".join(v.split()).strip()
+def _normalize_spaces(v: str) -> str:
+    return " ".join((v or "").split()).strip()
+
+
+def _validate_name_field(field: str, v: str) -> str:
+    v = _normalize_spaces(v)
+
+    if not v:
+        raise ValueError(f"{field} ne doit pas être vide")
     if "<" in v or ">" in v:
-        raise ValueError("full_name ne doit pas contenir '<' ni '>'")
+        raise ValueError(f"{field} ne doit pas contenir '<' ni '>'")
     if not _NAME_RE.match(v):
-        raise ValueError("full_name contient des caractères non autorisés")
+        raise ValueError(f"{field} contient des caractères non autorisés")
     return v
+
+
+def _validate_first_name(v: str) -> str:
+    return _validate_name_field("first_name", v)
+
+
+def _validate_last_name(v: str) -> str:
+    return _validate_name_field("last_name", v)
 
 
 def _validate_password(v: str) -> str:
@@ -34,5 +49,6 @@ def _validate_password(v: str) -> str:
     return v
 
 
-FullNameStr = Annotated[str, AfterValidator(_validate_full_name)]
+NameFirstStr = Annotated[str, AfterValidator(_validate_first_name)]
+NameLastStr = Annotated[str, AfterValidator(_validate_last_name)]
 PasswordStr = Annotated[str, AfterValidator(_validate_password)]

--- a/backend/app/script/init_db_async.py
+++ b/backend/app/script/init_db_async.py
@@ -39,7 +39,12 @@ async def create_schema() -> None:
             admin_exists = await any_admin_exists(db)
             if not admin_exists:
                 admin = await create_user(
-                    db, settings.ROOT_EMAIL, settings.ROOT_PASSWORD, settings.ROOT_NAME, role="ADMIN"
+                    db,
+                    settings.ROOT_EMAIL,
+                    settings.ROOT_PASSWORD,
+                    settings.ROOT_FIRST_NAME,
+                    settings.ROOT_LAST_NAME,
+                    role="ADMIN",
                 )
                 logger.info("Root admin created:")
             else:

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -5,9 +5,13 @@ from app.repositories import user_repo
 from sqlalchemy.ext.asyncio import AsyncSession
 
 
-async def ensure_root_exists(db: AsyncSession, root_email: str, root_password: str, root_name: str):
+async def ensure_root_exists(
+    db: AsyncSession, root_email: str, root_password: str, root_first_name: str, root_last_name: str
+):
     if not await user_repo.any_admin_exists(db):
-        user = await user_repo.create_user(db, root_email, root_password, root_name, role="ADMIN")
+        user = await user_repo.create_user(
+            db, root_email, root_password, first_name=root_first_name, last_name=root_last_name, role="ADMIN"
+        )
         return user
     return None
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -31,4 +31,5 @@ The `.env` file contains the following variables:
 - Super admin instance account
     - `ROOT_EMAIL`: Instance super admin account login; default `admin@example.com`.
     - `ROOT_PASSWORD`: Instance super admin account password; NO DEFAULT CHANGE THE KEY.
-    - `ROOT_NAME`: Instance super admin account name; default `Admin Root`.
+    - `ROOT_FIRST_NAME`: Instance super admin account first name; default `Admin`.
+    - `ROOT_LAST_NAME`: Instance super admin account last name; default `Root`.

--- a/frontend/src/components/PrivateTopbar.tsx
+++ b/frontend/src/components/PrivateTopbar.tsx
@@ -31,14 +31,22 @@ export default function PrivateTopbar() {
       ? DEFAULT_LOGO
       : resolveAssetUrl(logoUrlRaw);
 
-//   user n'est pas encore retouner au frontend mais l'idée est d'avoir les initiales du User
-  const userName = user?.full_name ?? t("dashboard.private.anonymous");
+  const userName = useMemo(() => {
+    if (!user) return t("dashboard.private.anonymous");
+    const first = (user.first_name || "").trim();
+    const last = (user.last_name || "").trim();
+    const full = `${first} ${last}`.replace(/\s+/g, " ").trim();
+    return full || t("dashboard.private.anonymous");
+  }, [user, t]);
+
   const initials = useMemo(() => {
-    const parts = (userName || "").trim().split(/\s+/).filter(Boolean);
-    const a = parts[0]?.[0] ?? "U";
-    const b = parts.length > 1 ? (parts[parts.length - 1]?.[0] ?? "") : "";
+    if (!user) return "U";
+    const firstParts = (user.first_name || "").trim().split(/\s+/).filter(Boolean);
+    const lastParts = (user.last_name || "").trim().split(/\s+/).filter(Boolean);
+    const a = firstParts[0]?.[0] ?? "U";
+    const b = lastParts.length > 0 ? (lastParts[lastParts.length - 1]?.[0] ?? "") : "";
     return (a + b).toUpperCase();
-  }, [userName]);
+  }, [user]);
 
   const curLang = (i18n.language || "").toLowerCase();
   const curBase = curLang.split("-")[0];

--- a/frontend/src/features/dashboard/Dashboard.tsx
+++ b/frontend/src/features/dashboard/Dashboard.tsx
@@ -1,5 +1,5 @@
 // Tableau de bord (zone privée) : affiche l’utilisateur connecté et pour l'instant un bouton de déconnexion
-import React from "react";
+import { useMemo } from "react";
 import { Link } from "react-router-dom";
 import { useAuth } from "@/contexts/AuthContext";
 import { useTranslation } from "react-i18next";
@@ -13,7 +13,13 @@ export default function Dashboard() {
   const { t } = useTranslation();
   const { primary, textColor, borderColor, hoverText05, hoverText07, hoverPrimary10, hoverPrimary15, hoverPrimary30, hoverPrimary90, cardBg } = useTheme();
 
-  const name = user?.full_name ?? t("dashboard.anonymous", "Anonyme");
+  const name = useMemo(() => {
+    if (!user) return t("dashboard.anonymous", "Anonyme");
+    const first = (user.first_name || "").trim();
+    const last = (user.last_name || "").trim();
+    const full = `${first} ${last}`.replace(/\s+/g, " ").trim();
+    return full || t("dashboard.anonymous", "Anonyme");
+  }, [user, t]);
   const role = user?.role ? String(user.role) : t("dashboard.roleUnknown", "Utilisateur");
 
   // placeholders KPI

--- a/frontend/src/services/admin.ts
+++ b/frontend/src/services/admin.ts
@@ -1,9 +1,10 @@
 // Services d’administration : création et suppression de membres via l’API
 import { apiFetch } from "@/shared/apiFetch";
-import { normalizeFullName, normalizeEmail } from "@/utils/normalize";
+import { normalizeName, normalizeEmail } from "@/utils/normalize";
 
 export type CreateMemberPayload = {
-  full_name: string;
+  first_name: string;
+  last_name: string;
   email: string;
   role: "ADMIN" | "MEMBER";
   password: string;
@@ -17,7 +18,8 @@ export async function createMember(form: {
   password: string;
 }) {
   const body: CreateMemberPayload = {
-    full_name: normalizeFullName(form.first_name, form.last_name),
+    first_name: normalizeName(form.first_name),
+    last_name: normalizeName(form.last_name),
     email: normalizeEmail(form.email),
     role: form.role,
     password: form.password,
@@ -36,7 +38,8 @@ export async function deleteMember(form: {
   role: "ADMIN" | "MEMBER";
 }) {
   const body = {
-    full_name: normalizeFullName(form.first_name, form.last_name),
+    first_name: normalizeName(form.first_name),
+    last_name: normalizeName(form.last_name),
     email: normalizeEmail(form.email),
     role: form.role,
   };

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -1,7 +1,7 @@
 // Service d’authentification (client) : login/refresh/logout + cache local
 import { apiFetch } from "@/shared/apiFetch";
 
-export type User = { id: string; email: string; full_name: string; role: "ADMIN" | "MEMBER" };
+export type User = { id: string; email: string; first_name: string; last_name: string; role: "ADMIN" | "MEMBER" };
 
 const REFRESH_KEY = "next_refresh_at"; // timestamp en ms
 

--- a/frontend/src/utils/normalize.ts
+++ b/frontend/src/utils/normalize.ts
@@ -1,7 +1,7 @@
-export function normalizeFullName(first: string, last: string): string {
-  return `${(first || "").trim()} ${(last || "").trim()}`
-    .replace(/\s+/g, " ")
+export function normalizeName(s: string): string {
+  return (s || "")
     .trim()
-    .replace(/[<>]/g, ""); // on retire < >
+    .replace(/\s+/g, " ")
+    .replace(/[<>]/g, "");
 }
 export const normalizeEmail = (e: string) => (e || "").trim().toLowerCase();


### PR DESCRIPTION
### Objectif

Cette PR refactorise la gestion de l’identité utilisateur sur l’ensemble du **frontend et du backend** en remplaçant le champ full_name par deux champs explicites :
- first_name
- last_name

### Changements principaux
#### Backend
- Ajout des colonnes `first_name` et `last_name` dans la table `users`
- Le champ `full_name` devient un **champ dérivé** (first_name + last_name)
- Mise à jour du modèle SQLAlchemy `User`
- Mise à jour des repositories et services pour utiliser `first_name` / `last_name`
- Remplacement de `full_name` par `first_name` / `last_name` dans les schémas API
- Ajout de validateurs stricts mais flexibles :
- Support des espaces, accents, tirets et apostrophes
- Refus des caractères `<` et `>`
- Conservation des espaces internes (noms composés)
- Mise à jour de l’endpoint `/user/me` avec un **payload contrôlé** :
   `{ "id", "email", "first_name", "last_name", "role" }`
- Mise à jour des routes admin (`addUser`, `deleteUser`) avec comparaison normalisée des noms
- Remplacement de `ROOT_NAME` par :
  - `ROOT_FIRST_NAME`
  - `ROOT_LAST_NAME`
#### Frontend
- Remplacement de tous les usages de `full_name` par :
``${first_name} ${last_name}`.trim()`
- Mise à jour des composants :
  - `PrivateTopbar` (nom affiché + initiales)
  - `Dashboard` (message de bienvenue)
  - `authService` (type `User`)
- Calcul correct des initiales pour les noms composés :
  - Jean Pierre Van Damme → **JD**
- La normalisation côté frontend conserve les espaces internes
- Les données stockées dans `localStorage` sont **strictement limitées à l’UI** :
`{ "first_name", "last_name", "role" }`

### image

<img width="1437" height="713" alt="Capture d’écran 2026-01-27 à 10 10 36" src="https://github.com/user-attachments/assets/5d8500d5-3528-4ae5-807a-fa2049f121c2" />
