### PR TITLE
Fix #193 ajouts d'un delai lors du login

### DIFF
--- a/backend/app/api/router/auth.py
+++ b/backend/app/api/router/auth.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+import asyncio
 
 
 from app.api.dependencies import get_current_user
@@ -23,6 +24,8 @@ async def login(user_credentials: UserLogin, response: Response, db: AsyncSessio
     """Authenticate user by email and return access token."""
     user = await authenticate_user(db, user_credentials.email, user_credentials.password)
     if not user:
+        # délai de 2 secondes volontaire pour ralentir le brute-force
+        await asyncio.sleep(2.0)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Incorrect email or password",


### PR DESCRIPTION
### Objectif

Cette PR ajoute un délai volontaire côté serveur lors d’un échec d’authentification afin de limiter les attaques par brute-force sur l’endpoint de connexion.

### Changements principaux
- Ajout d’un délai artificiel (`~2 seconde`) **uniquement lorsque les identifiants sont incorrects**
- Utilisation de `asyncio.sleep()` pour ne pas bloquer l’event loop (FastAPI async)
- Aucun délai ajouté lorsque la connexion est valide