### PR TITLE
Fix #199 ajouts fonction supprimer dans page show

### DIFF
--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -437,7 +437,13 @@
       "insights": "Insights",
       "insightsHint": "Carte / stats / infos",
       "text": "Texte",
-      "noChildren": "Aucune données"
+      "noChildren": "Aucune données",
+      "confirmClear": "Confirmer",
+      "deleteError": "Erreur de suppression",
+      "confirmDeleteTitle": "Confirmer la suppression",
+      "noSelection": "Aucun champ sélectionné.",
+      "confirmClearMessage": "Vous allez effacer les champs suivants :\n- {{fields}}",
+      "deleting": "Suppression..."    
     }
   },
   "roles": {


### PR DESCRIPTION
### Objectif

Cette PR introduit une **suppression fine et contrôlée des champs** sur la page de détail (`PageShow`), permettant de supprimer **uniquement certaines valeurs** d’un enregistrement, sans impacter l’ensemble de la ligne ni les entités enfants.

### Changements principaux
#### Mode suppression interactif
- Le bouton **Supprimer** active un mode de sélection.
- L’utilisateur peut choisir précisément quels champs supprimer :
  - Informations principales
  - Champs multilingues (langues)
- Les champs protégés (ex. `id`, `uid`) ne sont pas sélectionnables.
#### UX améliorée
- Les cases à cocher sont **préservées dans la mise en page** (placeholder fixe), évitant tout décalage visuel lors de l’activation du mode suppression.
- Bouton **Confirmer** désactivé tant qu’aucun champ n’est sélectionné.
- Confirmation explicite via une modale listant les champs concernés.
#### Suppression ciblée
- Utilisation de l’endpoint existant `/delete` avec le paramètre `clear_fields`.
- Seuls les champs sélectionnés sont effacés :
  - aucune suppression complète de la ligne
  - aucun impact sur les enfants
- Rafraîchissement automatique des données après succès.
#### Comportement robuste
- Correction du flux de confirmation :
  - un seul clic requis pour valider la suppression
  - préparation du contexte de suppression avant l’ouverture de la modale
- Gestion des erreurs et états de chargement via le hook `useDelete`.

### Images
<img width="1443" height="720" alt="Capture d’écran 2026-01-29 à 17 51 09" src="https://github.com/user-attachments/assets/0ceca666-6acb-4488-8cfe-f635c4cd5292" />

<img width="1437" height="712" alt="Capture d’écran 2026-01-29 à 17 52 16" src="https://github.com/user-attachments/assets/75a31337-7226-4838-81c0-300c173464eb" />

<img width="1437" height="713" alt="Capture d’écran 2026-01-29 à 17 52 44" src="https://github.com/user-attachments/assets/d7449cf0-1559-4c82-9695-98fae661af12" />

<img width="1439" height="717" alt="Capture d’écran 2026-01-29 à 17 52 56" src="https://github.com/user-attachments/assets/db5230ce-609b-454b-8b16-60f6d1b3c2c1" />

<img width="1438" height="709" alt="Capture d’écran 2026-01-29 à 17 53 08" src="https://github.com/user-attachments/assets/281eadc4-a0c4-4e00-9393-47f2dc8c06cd" />




