### PR TITLE
Fix #246 : fix input from user causing crashed from docker install

### DIFF
--- a/backend/app/script/init_db_async.py
+++ b/backend/app/script/init_db_async.py
@@ -17,14 +17,12 @@ from app.script.populate_geo_db import populate_async_geo
 logger = logging.getLogger(__name__)
 
 
-async def create_schema(is_demo: bool) -> None:
+async def create_schema(is_demo: bool, delete_force: bool) -> None:
     try:
         await ensure_extensions()
     except Exception as e:
         logger.warning("Could not ensure extensions (unaccent/postgis): %s", e)
-
-    confirm = input("Do you want to drop the database and start from scratch? [y/N] > ")
-    if confirm.lower() == "y":
+    if delete_force:
         async with engine.begin() as conn:
             # Drop toute les tables pour repartir de 0
             logger.warning("Dropping all tables (destructive operation).")
@@ -73,6 +71,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-d", dest="demo", action="store_true")
+    parser.add_argument("-f", dest="force", action="store_true")
     args = parser.parse_args()
     configure_logging()
-    asyncio.run(create_schema(args.demo))
+    asyncio.run(create_schema(args.demo, args.force))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,7 @@ services:
     depends_on:
       db:
         condition: service_healthy
-    command: ["python", "-m", "app.script.init_db_async"]
+    command: ["python", "-m", "app.script.init_db_async", "-f"]
     working_dir: /app/backend
     volumes:
       - ./backend:/app/backend:z  


### PR DESCRIPTION
This PR aims to resolve the little bug that cause a crash when we initialise the db from the docker.

Instead of asking user from a prompt, we use an argument passed to the script !