### PR TITLE
Fix ##258 patch erreur et correction enfant dans page show

### DIFF
--- a/backend/app/api/router/pageShow.py
+++ b/backend/app/api/router/pageShow.py
@@ -57,9 +57,9 @@ async def show_children(
 
     child_entity = EntityEnum(child.entity)  # ex: "district"
     items, total = await get_children_paginated(
-        db,
+        db=db,
         child_entity=child_entity,
-        fk_field=child.fk_field,
+        child_meta=child,
         parent_uid=uid,
         page=page,
         per_page=per_page,

--- a/backend/app/repositories/pageShow_children_repo.py
+++ b/backend/app/repositories/pageShow_children_repo.py
@@ -1,16 +1,27 @@
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, List, Optional, Type
 
 
+from app.models.question_category_option_association import QuestionCategoryOptionAssociation
+from app.models.question_global_option_association import QuestionGlobalOptionAssociation
+from app.models.question_option_association import QuestionOptionAssociation
 from app.repositories.pageShow_repo import ENTITY_MODEL_MAP
 from app.schemas.pageAll import EntityEnum
+from app.schemas.pageShow import ShowMetaChild
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
+
+
+ASSOCIATION_MODEL_MAP = {
+    "question_option_association": QuestionOptionAssociation,
+    "question_global_option_association": QuestionGlobalOptionAssociation,
+    "question_category_option_association": QuestionCategoryOptionAssociation,
+}
 
 
 async def get_children_paginated(
     db: AsyncSession,
     child_entity: EntityEnum,
-    fk_field: str,
+    child_meta: ShowMetaChild,
     parent_uid: int,
     page: int,
     per_page: int,
@@ -19,19 +30,64 @@ async def get_children_paginated(
     if model is None:
         return [], 0
 
-    fk_col = getattr(model, fk_field, None)
-    if fk_col is None:
-        return [], 0
-
-    where_clause = fk_col == parent_uid
-
-    total_req = select(func.count()).select_from(model).where(where_clause)
-    total_res = await db.execute(total_req)
-    total = int(total_res.scalar() or 0)
-
     offset = (page - 1) * per_page
-    req = select(model).where(where_clause).offset(offset).limit(per_page)
-    res = await db.execute(req)
-    items = list(res.scalars().all())
 
-    return items, total
+    if child_meta.relation_type == "direct":
+        if not child_meta.fk_field:
+            return [], 0
+
+        fk_col = getattr(model, child_meta.fk_field, None)
+        if fk_col is None:
+            return [], 0
+
+        where_clause = fk_col == parent_uid
+
+        total_req = select(func.count()).select_from(model).where(where_clause)
+        total_res = await db.execute(total_req)
+        total = int(total_res.scalar() or 0)
+
+        req = select(model).where(where_clause).offset(offset).limit(per_page)
+        res = await db.execute(req)
+        items = list(res.scalars().all())
+        return items, total
+
+    if child_meta.relation_type == "association":
+        if (
+            not child_meta.association_table
+            or not child_meta.association_source_field
+            or not child_meta.association_target_field
+        ):
+            return [], 0
+
+        association_model = ASSOCIATION_MODEL_MAP.get(child_meta.association_table)
+        if association_model is None:
+            return [], 0
+
+        source_col = getattr(association_model, child_meta.association_source_field, None)
+        target_col = getattr(association_model, child_meta.association_target_field, None)
+        target_uid_col = getattr(model, child_meta.target_uid_field, None)
+
+        if source_col is None or target_col is None or target_uid_col is None:
+            return [], 0
+
+        total_req = (
+            select(func.count())
+            .select_from(model)
+            .join(association_model, target_uid_col == target_col)
+            .where(source_col == parent_uid)
+        )
+        total_res = await db.execute(total_req)
+        total = int(total_res.scalar() or 0)
+
+        req = (
+            select(model)
+            .join(association_model, target_uid_col == target_col)
+            .where(source_col == parent_uid)
+            .offset(offset)
+            .limit(per_page)
+        )
+        res = await db.execute(req)
+        items = list(res.scalars().all())
+        return items, total
+
+    return [], 0

--- a/backend/app/repositories/pageShow_repo.py
+++ b/backend/app/repositories/pageShow_repo.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, Optional, Type
 
 
+from app.models.answer import Answer
 from app.models.canton import Canton
 from app.models.commune import Commune
 from app.models.district import District
@@ -23,6 +24,7 @@ ENTITY_MODEL_MAP: Dict[EntityEnum, Type[Any]] = {
     EntityEnum.question_global: QuestionGlobal,
     EntityEnum.question_category: QuestionCategory,
     EntityEnum.option: Option,
+    EntityEnum.answer: Answer,
 }
 
 

--- a/backend/app/schemas/pageAll.py
+++ b/backend/app/schemas/pageAll.py
@@ -14,6 +14,7 @@ class EntityEnum(str, Enum):
     question_category = "question_category"
     option = "option"
     survey = "survey"
+    answer = "answer"
 
 
 class OrderByEnum(str, Enum):

--- a/backend/app/schemas/pageShow.py
+++ b/backend/app/schemas/pageShow.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 
 from pydantic import BaseModel
@@ -33,7 +33,18 @@ class ShowMetaChild(BaseModel):
     key: str
     title: str
     entity: str
-    fk_field: str
+
+    relation_type: Literal["direct", "association"] = "direct"
+
+    # direct relation
+    fk_field: Optional[str] = None
+
+    # association relation
+    association_table: Optional[str] = None
+    association_source_field: Optional[str] = None
+    association_target_field: Optional[str] = None
+    target_uid_field: str = "uid"
+
     per_page: int = 10
     columns: List[ShowChildColumn]
     actions: ShowMetaChildActions = ShowMetaChildActions()
@@ -56,7 +67,6 @@ class ShowResponse(BaseModel):
     data: Optional[Dict[str, Any]] = None
 
 
-# réponse paginée pour un child
 class ShowChildrenData(BaseModel):
     items: List[Dict[str, Any]]
     total: int

--- a/backend/app/services/pageShow_meta.py
+++ b/backend/app/services/pageShow_meta.py
@@ -8,16 +8,14 @@ from app.schemas.pageShow import (
 )
 
 
-LANG_MAP = {"de": "Deutsch", "fr": "Français", "en": "English", "it": "Italiano", "ro": "Rumantsch"}
-
 ENTITY_META = {
     "commune": ShowMeta(
         entity="commune",
         title_key="name",
         hide_keys=["uid"],
         fields=[
-            ShowMetaField(key="code", label="Code", kind="text"),
-            ShowMetaField(key="name", label="Name", kind="text"),
+            ShowMetaField(key="code", label="Code"),
+            ShowMetaField(key="name", label="Name"),
         ],
         languages={"de": "name_de", "fr": "name_fr", "en": "name_en", "it": "name_it", "ro": "name_ro"},
         actions=ShowMetaActions(can_edit=False, can_delete=False),
@@ -37,6 +35,7 @@ ENTITY_META = {
                 key="communes",
                 title="Communes",
                 entity="commune",
+                relation_type="direct",
                 fk_field="district_uid",
                 per_page=10,
                 columns=[
@@ -44,7 +43,7 @@ ENTITY_META = {
                     ShowChildColumn(key="code", label="Code"),
                     ShowChildColumn(key="name", label="Name"),
                 ],
-                actions=ShowMetaChildActions(show=True, edit=False, delete=False),
+                actions=ShowMetaChildActions(show=True),
             )
         ],
     ),
@@ -64,6 +63,7 @@ ENTITY_META = {
                 key="districts",
                 title="Districts",
                 entity="district",
+                relation_type="direct",
                 fk_field="canton_uid",
                 per_page=10,
                 columns=[
@@ -71,7 +71,7 @@ ENTITY_META = {
                     ShowChildColumn(key="code", label="Code"),
                     ShowChildColumn(key="name", label="Name"),
                 ],
-                actions=ShowMetaChildActions(show=True, edit=False, delete=False),
+                actions=ShowMetaChildActions(show=True),
             )
         ],
     ),
@@ -90,6 +90,7 @@ ENTITY_META = {
                 key="questions",
                 title="Questions per survey",
                 entity="question_per_survey",
+                relation_type="direct",
                 fk_field="survey_uid",
                 per_page=10,
                 columns=[
@@ -121,14 +122,30 @@ ENTITY_META = {
                 key="answers",
                 title="Answers",
                 entity="answer",
+                relation_type="direct",
                 fk_field="question_uid",
                 per_page=10,
                 columns=[
                     ShowChildColumn(key="uid", label="UID", kind="number"),
                     ShowChildColumn(key="year", label="Year", kind="year"),
                     ShowChildColumn(key="commune_uid", label="Commune uid", kind="number"),
-                    ShowChildColumn(key="option_uid", label="Option uid", kind="number"),
                     ShowChildColumn(key="value", label="Value"),
+                ],
+                actions=ShowMetaChildActions(show=True, edit=True, delete=True),
+            ),
+            ShowMetaChild(
+                key="options",
+                title="Options",
+                entity="option",
+                relation_type="association",
+                association_table="question_option_association",
+                association_source_field="question_uid",
+                association_target_field="option_uid",
+                per_page=10,
+                columns=[
+                    ShowChildColumn(key="uid", label="UID", kind="number"),
+                    ShowChildColumn(key="value", label="Value"),
+                    ShowChildColumn(key="label", label="Label"),
                 ],
                 actions=ShowMetaChildActions(show=True, edit=True, delete=True),
             ),
@@ -149,6 +166,7 @@ ENTITY_META = {
                 key="questions_linked",
                 title="Linked questions (per survey)",
                 entity="question_per_survey",
+                relation_type="direct",
                 fk_field="question_global_uid",
                 per_page=10,
                 columns=[
@@ -159,7 +177,23 @@ ENTITY_META = {
                     ShowChildColumn(key="survey_uid", label="Survey uid", kind="number"),
                 ],
                 actions=ShowMetaChildActions(show=True, edit=True, delete=True),
-            )
+            ),
+            ShowMetaChild(
+                key="options",
+                title="Options",
+                entity="option",
+                relation_type="association",
+                association_table="question_global_option_association",
+                association_source_field="question_uid",
+                association_target_field="option_uid",
+                per_page=10,
+                columns=[
+                    ShowChildColumn(key="uid", label="UID", kind="number"),
+                    ShowChildColumn(key="value", label="Value"),
+                    ShowChildColumn(key="label", label="Label"),
+                ],
+                actions=ShowMetaChildActions(show=True, edit=True, delete=True),
+            ),
         ],
     ),
     "question_category": ShowMeta(
@@ -176,7 +210,10 @@ ENTITY_META = {
                 key="options",
                 title="Options",
                 entity="option",
-                fk_field="question_category_uid",
+                relation_type="association",
+                association_table="question_category_option_association",
+                association_source_field="question_uid",
+                association_target_field="option_uid",
                 per_page=10,
                 columns=[
                     ShowChildColumn(key="uid", label="UID", kind="number"),
@@ -189,6 +226,7 @@ ENTITY_META = {
                 key="questions_global",
                 title="Global questions",
                 entity="question_global",
+                relation_type="direct",
                 fk_field="question_category_uid",
                 per_page=10,
                 columns=[
@@ -201,6 +239,7 @@ ENTITY_META = {
                 key="questions_per_survey",
                 title="Questions per survey",
                 entity="question_per_survey",
+                relation_type="direct",
                 fk_field="question_category_uid",
                 per_page=10,
                 columns=[
@@ -221,37 +260,18 @@ ENTITY_META = {
         fields=[
             ShowMetaField(key="value", label="Value"),
             ShowMetaField(key="label", label="Label"),
-            ShowMetaField(key="question_category_uid", label="Category uid", kind="number"),
         ],
         languages={"de": "text_de", "fr": "text_fr", "en": "text_en", "it": "text_it", "ro": "text_ro"},
         actions=ShowMetaActions(can_edit=True, can_delete=True),
-        children=[
-            ShowMetaChild(
-                key="answers",
-                title="Answers",
-                entity="answer",
-                fk_field="option_uid",
-                per_page=10,
-                columns=[
-                    ShowChildColumn(key="uid", label="UID", kind="number"),
-                    ShowChildColumn(key="year", label="Year", kind="year"),
-                    ShowChildColumn(key="question_uid", label="Question uid", kind="number"),
-                    ShowChildColumn(key="commune_uid", label="Commune uid", kind="number"),
-                    ShowChildColumn(key="value", label="Value"),
-                ],
-                actions=ShowMetaChildActions(show=True, edit=True, delete=True),
-            ),
-        ],
     ),
     "answer": ShowMeta(
         entity="answer",
-        title_key="uid",  # ou "year"
+        title_key="uid",
         hide_keys=["uid"],
         fields=[
             ShowMetaField(key="year", label="Year", kind="year"),
             ShowMetaField(key="question_uid", label="Question uid", kind="number"),
             ShowMetaField(key="commune_uid", label="Commune uid", kind="number"),
-            ShowMetaField(key="option_uid", label="Option uid", kind="number"),
             ShowMetaField(key="value", label="Value"),
         ],
         languages=None,

--- a/frontend/src/features/pageShow/show_type.ts
+++ b/frontend/src/features/pageShow/show_type.ts
@@ -8,6 +8,7 @@ export enum Entity {
   QuestionGlobal = "question_global",
   QuestionCategory = "question_category",
   Option = "option",
+  Answer = "answer",
 }
 
 export type ShowChildColumn = {


### PR DESCRIPTION
### Objectif

Cette PR améliore fortement l’expérience utilisateur et la robustesse du système de **page Show** en refondant la gestion des entités liées (**children**) pour qu’elle reflète correctement la structure réelle de la base de données, y compris les relations directes et les relations via tables d’association.

---

### Changements principaux

#### Correction du support de l’entité `answer`
- Ajout de l’entité **`answer`** dans les enums et mappings backend/frontend.
- Correction de l’incohérence entre le `meta` et les entités réellement supportées.
- Suppression de l’erreur backend liée à :
  - `ValueError: 'answer' is not a valid EntityEnum`
- Activation correcte de l’affichage des réponses dans les vues de détail.

---

#### Alignement du système Show avec la structure de la base
- Relecture et adaptation du système selon les modèles réels :
  - `Answer`
  - `QuestionPerSurvey`
  - `Option`
  - tables d’association
- Suppression des hypothèses incorrectes sur certaines relations directes.
- Mise en cohérence du `pageShow_meta` avec les colonnes réellement présentes dans les tables.
- Correction des champs affichés pour éviter les colonnes inexistantes.

---

#### Refonte de la gestion des enfants (`children`)
- Généralisation du système pour gérer deux types de relations :
  - **relations directes** via clé étrangère
  - **relations d’association** via table intermédiaire
- Ajout d’une logique plus propre et extensible pour charger les enfants paginés.
- Fin de la dépendance exclusive à un simple `fk_field`.
- Base plus solide pour gérer les relations complexes dans les pages Show.

---

#### Support des relations many-to-many
- Ajout du support des tables d’association pour charger correctement :
  - les **options d’une question par survey**
  - les **options d’une question globale**
  - les **options d’une catégorie**
- Utilisation de jointures adaptées au lieu d’une recherche naïve par clé étrangère directe.
- Meilleure représentation des vraies relations métier dans l’interface d’administration.

---

#### Nettoyage et correction du `meta`
- Suppression des champs qui n’existent pas réellement dans certains modèles.
- Correction des colonnes affichées pour `answer`.
- Suppression des relations enfants incohérentes avec le schéma actuel.
- Clarification de la configuration des entités pour rendre le système plus maintenable.

---

#### Amélioration de la stabilité du backend
- Réduction du risque d’erreurs runtime causées par :
  - des entités absentes de l’enum
  - des clés étrangères inexistantes
  - des relations mal décrites dans le meta
- Comportement plus prévisible lors du chargement des pages détail.
- Architecture plus robuste pour les futures extensions CRUD/show.

---

#### Préparation pour l’évolution future
- Structure désormais prête à accueillir plus facilement :
  - de nouvelles entités
  - de nouveaux children
  - d’autres relations complexes
- Système plus modulaire et plus simple à faire évoluer.
- Meilleure séparation entre :
  - configuration `meta`
  - logique de chargement
  - structure réelle des modèles SQLAlchemy

---

### Résultat

- Les pages **Show** reflètent désormais correctement la structure réelle de la base de données.
- Les enfants d’une entité sont chargés de manière **plus fiable et plus cohérente**.
- L’erreur backend liée à l’entité `answer` est supprimée.
- Les relations complexes via tables d’association sont maintenant correctement prises en charge.
- Le système est **plus propre, plus robuste et plus maintenable**.
- Cette base facilite les futures évolutions de l’interface d’administration.

---

### Images
<img width="1413" height="679" alt="Capture d’écran 2026-04-14 à 18 48 48" src="https://github.com/user-attachments/assets/437d1c6f-2898-4366-b9a3-71e211022e99" />
<img width="1425" height="677" alt="Capture d’écran 2026-04-14 à 18 49 09" src="https://github.com/user-attachments/assets/a174a667-7f3d-48c7-aaba-7eb76e540fb4" />
<img width="1422" height="682" alt="Capture d’écran 2026-04-14 à 18 51 01" src="https://github.com/user-attachments/assets/1646bb3d-2d38-4d69-af90-fa686df820ff" />