### PR TITLE
Fix #97 : remove hardcoded backend url

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -7,7 +7,7 @@ DB_PASSWORD=postgres
 
 # Backend
 BACKEND_HOST=localhost
-BACKEND_PORT=8765
+BACKEND_PORT=1234
 
 # Frontend
 FRONTEND_HOST=localhost
@@ -28,6 +28,7 @@ COOKIE_SAMESITE=lax
 # CORS and API
 CORS_ORIGINS=http://$FRONTEND_HOST:$FRONTEND_PORT
 API_URL=http://$BACKEND_HOST:$BACKEND_PORT
+VITE_API_BASE_URL=$API_URL
 
 # Super admin instance account
 ROOT_EMAIL=admin@example.com

--- a/.env.dist
+++ b/.env.dist
@@ -7,7 +7,7 @@ DB_PASSWORD=postgres
 
 # Backend
 BACKEND_HOST=localhost
-BACKEND_PORT=1234
+BACKEND_PORT=8000
 
 # Frontend
 FRONTEND_HOST=localhost

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,11 +39,10 @@ services:
     build:
       context: .
       dockerfile: docker/frontend/Dockerfile
-      args:
-        # Pass the backend API URL as a build argument for React
-        - REACT_APP_API_URL=http://localhost:8000
     ports:
       - "3000:3000"
+    env_file:
+      - .env
     volumes:
       - ./frontend:/app:Z
       - /app/node_modules
@@ -76,7 +75,7 @@ services:
     depends_on:
       db:
         condition: service_healthy
-    command: ["python", "-m", "app.script.init_db_async", "-d"]
+    command: ["python", "-m", "app.script.init_db_async", "-d", "-f"]
     working_dir: /app/backend
     volumes:
       - ./backend:/app/backend:z  

--- a/frontend/src/shared/apiFetch.ts
+++ b/frontend/src/shared/apiFetch.ts
@@ -30,14 +30,10 @@ export class ApiError extends Error {
 // Auth via cookie HttpOnly (sinon on utilise Authorization: Bearer)
 const AUTH_VIA_COOKIE = true;
 
-/** TODO: Base URL de l’API ne pas laisser "http://localhost:8000" en dur */
 function resolveBaseUrl(): string {
   const im = (import.meta as any)?.env ?? {};
   return (
-    im.VITE_API_BASE_URL ||
-    im.REACT_APP_API_URL ||
-    (window as any).__API_URL__ ||
-    "http://localhost:8000"
+    im.VITE_API_BASE_URL
   );
 }
 const BASE_URL = resolveBaseUrl();


### PR DESCRIPTION
This PR aims to remove the hardcoded backend url in the frontend code, for that we use the `.env` file with the predix `VITE_` to ensure that only the backend url in `.env` is sended to frontend for security purpose.