### PR TITLE
Fix #286 permettre l'accès au bouton menue en tout temps

### DIFF
--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -82,7 +82,7 @@ export default function Navbar() {
         className={[
           "fixed top-3 left-3 inline-flex items-center justify-center",
           "w-16 h-16 sm:w-18 sm:h-18 rounded-2xl bg-transparent",
-          open ? "opacity-0 pointer-events-none z-40" : "opacity-100 z-50",
+          open ? "opacity-0 pointer-events-none z-[3400]" : "opacity-100 z-[3450]",
         ].join(" ")}
         // décale les contrôles Leaflet sous le bouton (utile même quand le bouton est masqué)
         style={{ "--leaflet-top-offset": "96px" } as React.CSSProperties}
@@ -104,7 +104,7 @@ export default function Navbar() {
 
       {/* Drawer + Overlay (au-dessus du reste de la map) */}
       {open && (
-        <div className="fixed inset-0 z-50">
+        <div className="fixed inset-0 z-[3450]">
           <div className="absolute inset-0" style={{ backgroundColor: navbarOverlayBg }} onClick={() => setOpen(false)} aria-hidden />
           <div
             ref={panelRef}

--- a/frontend/src/utils/MapLoadingOverlay.tsx
+++ b/frontend/src/utils/MapLoadingOverlay.tsx
@@ -16,7 +16,7 @@ export default function MapLoadingOverlay({ label, type = "loading" }: Props) {
 
   return (
     <div
-      className="absolute inset-0 z-[3400] flex items-center justify-center"
+      className="absolute inset-0 z-[3200] flex items-center justify-center"
       style={{
         backgroundColor: `${background}CC`,
         backdropFilter: "blur(2px)",


### PR DESCRIPTION
### Objectif

Cette PR corrige la superposition entre le voile de chargement de la carte et le bouton de menu de la navbar.

Le bouton du menu reste désormais accessible au-dessus du voile afin de permettre à l’utilisateur d’ouvrir la navigation et de modifier les options disponibles, même lorsqu’un overlay est affiché sur la carte.

---

### Changements principaux

#### Correction de l’ordre d’affichage du bouton de menu
- Mise à jour du `z-index` du bouton flottant de la navbar.
- Le bouton passe maintenant au-dessus du voile de chargement de la carte.
- Le bouton reste prioritaire visuellement lorsque le menu est fermé.
- Cela permet à l’utilisateur d’accéder au menu même si la carte est temporairement bloquée par un overlay.

---

#### Ajustement du z-index du drawer de navigation
- Mise à jour du `z-index` du conteneur du drawer.
- Le menu latéral de la navbar passe maintenant au-dessus de la carte et de son overlay.
- L’overlay de la navbar conserve son comportement de fermeture au clic extérieur.
- Le panneau de navigation reste accessible et lisible lorsqu’il est ouvert.

---

#### Réduction du z-index du voile de carte
- Le `z-index` du composant `MapLoadingOverlay` a été abaissé.
- Le voile reste au-dessus de la carte pour empêcher les interactions directes avec celle-ci.
- Le voile ne bloque plus l’accès au bouton de menu de la navbar.
- L’affichage du chargement et des messages d’action reste inchangé.

---

#### Préservation du comportement existant
- Le fonctionnement du bouton de menu reste inchangé.
- Le menu continue de s’ouvrir et de se fermer normalement.
- La fermeture au clic extérieur reste conservée.
- La fermeture avec la touche `Escape` reste conservée.
- Le changement de langue reste inchangé.
- Le switch de thème reste inchangé.
- Le comportement du voile de chargement de la carte reste identique visuellement.

---

### Résultat

- Le bouton de menu de la navbar est maintenant accessible au-dessus du voile de la carte.
- L’utilisateur peut ouvrir le menu même lorsqu’une sélection de question ou de date est demandée.
- Le drawer de navigation s’affiche correctement au-dessus de la carte.
- Le voile continue de bloquer uniquement les interactions avec la carte.
- L’ordre d’affichage entre la carte, le voile, le menu et le bouton est plus cohérent.
- La correction reste simple et limitée aux `z-index`, sans modifier la logique existante.

---

### Images
<img width="1424" height="679" alt="Capture d’écran 2026-05-27 à 11 34 52" src="https://github.com/user-attachments/assets/52c20652-263a-48e8-8670-1cda31760cd1" />
<img width="1426" height="680" alt="Capture d’écran 2026-05-27 à 11 35 10" src="https://github.com/user-attachments/assets/79d7f33a-d3cc-42df-83ee-69712e6dad2e" />