### PR TITLE
Fix #299 compress unused file for new data

### DIFF
--- a/backend/app/core/task.py
+++ b/backend/app/core/task.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+import os
+import time
+
+
+from app.services.data_import.data_import_storage_service import create_archive
+
+
+def compress_work_directory():
+    UPLOAD_DIR = Path("tmp/data_imports")
+    threshold = time.time() - 7200
+    for dir in UPLOAD_DIR.iterdir():
+        if dir.is_dir():
+            if dir.stat().st_mtime < threshold:
+                create_archive(dir.name)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,3 +1,4 @@
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 
@@ -17,14 +18,28 @@ from app.api.router import (
 )
 from app.core.middleware import setup_middlewares
 from app.core.paths import STATIC_FS_ROOT, STATIC_URL_ROOT
+from app.core.task import compress_work_directory
 from app.db import get_db
+from apscheduler.schedulers.background import BackgroundScheduler
 from fastapi import Depends, FastAPI
 from fastapi.staticfiles import StaticFiles
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 
-app = FastAPI(title="IDHEAP Data Hub API")
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # At startup
+    scheduler = BackgroundScheduler()
+    scheduler.add_job(compress_work_directory, "interval", hours=2)
+    scheduler.start()
+    # Start to handle request
+    yield
+    # At shutdown
+    scheduler.shutdown()
+
+
+app = FastAPI(title="IDHEAP Data Hub API", lifespan=lifespan)
 
 setup_middlewares(app)
 

--- a/backend/app/services/data_import/data_import_service.py
+++ b/backend/app/services/data_import/data_import_service.py
@@ -17,7 +17,9 @@ from app.services.data_import.data_import_normalizer_service import normalize_da
 from app.services.data_import.data_import_preview_service import build_preview_payload
 from app.services.data_import.data_import_reader_service import read_import_file
 from app.services.data_import.data_import_storage_service import (
+    create_archive,
     delete_import_dir,
+    extract_archive,
     get_import_dir,
     read_analysis,
     read_frame,
@@ -32,6 +34,15 @@ from app.services.data_import.data_import_storage_service import (
 )
 from fastapi import UploadFile
 from sqlalchemy.ext.asyncio import AsyncSession
+import pandas as pd
+
+
+async def save_compress_upload(import_id: str) -> bool:
+    try:
+        create_archive(import_id)
+        return True
+    except:
+        return False
 
 
 async def save_import_upload(file: UploadFile) -> dict[str, Any]:
@@ -50,12 +61,17 @@ async def save_import_upload(file: UploadFile) -> dict[str, Any]:
     content = await file.read()
     raw_path.write_bytes(content)
 
+    df = read_import_file(raw_path)
+    rows, columns = df.shape
+
     metadata = {
         "import_id": import_id,
         "filename": filename,
         "size": len(content),
         "raw_path": str(raw_path),
         "created_at": datetime.now(timezone.utc).isoformat(),
+        "columns": columns,
+        "rows": rows,
     }
 
     write_metadata(import_dir, metadata)
@@ -91,8 +107,8 @@ async def list_import_jobs() -> list[dict[str, Any]]:
                 "size": int(metadata.get("size") or 0),
                 "created_at": metadata.get("created_at"),
                 "analyzed": analysis is not None,
-                "rows": analysis.get("rows") if analysis else None,
-                "columns": analysis.get("columns") if analysis else None,
+                "rows": metadata.get("rows"),
+                "columns": metadata.get("columns"),
                 "total_issues": analysis.get("total_issues") if analysis else None,
                 "detected_survey_name": detected_survey.get("name"),
                 "detected_survey_year": detected_survey.get("year"),
@@ -105,6 +121,10 @@ async def list_import_jobs() -> list[dict[str, Any]]:
 async def get_import_summary(import_id: str) -> dict[str, Any]:
     import_dir = get_import_dir(import_id)
     analysis_path = import_dir / "analysis.json"
+    tar_filename = import_dir / "content.tar.gz"
+    if tar_filename.exists():
+
+        extract_archive(import_id)
 
     if not analysis_path.exists():
         raise ValueError("Import has not been analyzed yet")
@@ -122,6 +142,9 @@ async def analyze_import_file(
     import_id: str,
 ) -> dict[str, Any]:
     import_dir = get_import_dir(import_id)
+    archive_file = import_dir / "content.tar.gz"
+    if archive_file.exists():
+        extract_archive(import_id)
     metadata = read_metadata(import_dir)
 
     df = read_import_file(Path(metadata["raw_path"]))

--- a/backend/app/services/data_import/data_import_storage_service.py
+++ b/backend/app/services/data_import/data_import_storage_service.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Any
 import json
 import shutil
+import tarfile
 
 
 from app.services.data_import.data_import_reader_service import read_import_file
@@ -13,13 +14,34 @@ UPLOAD_DIR = Path("tmp/data_imports")
 UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
 
 
-# TODO: modifier la logique de stockage par la suite en .parquet ou autres formats
 def get_import_dir(import_id: str) -> Path:
     import_dir = UPLOAD_DIR / import_id
-
     if not import_dir.exists():
         raise ValueError("Import not found")
 
+    return import_dir
+
+
+def create_archive(import_id: str):
+    import_dir = get_import_dir(import_id)
+    tar_filename = import_dir / "content.tar.gz"
+    with tarfile.open(tar_filename, "w:gz") as tar:
+        for file in import_dir.iterdir():
+            if file.name != "metadata.json" and file.name != tar_filename.name:
+                tar.add(file, arcname=file.name)
+                file.unlink()
+
+
+def extract_archive(import_id: str) -> Path:
+    import_dir = get_import_dir(import_id)
+    tar_filename = import_dir / "content.tar.gz"
+    if not tar_filename.exists():
+        raise ValueError("Archived version doesn't exist")
+
+    with tarfile.open(tar_filename, "r:gz") as tar:
+        tar.extractall(import_dir)
+
+    tar_filename.unlink()
     return import_dir
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,3 +39,6 @@ pyproj==3.7.2
 
 # HTTP / Networking
 requests==2.32.5
+
+#Job schuleduling
+APScheduler==3.11.3


### PR DESCRIPTION
This PR aims to add a system to compress file that are used for new survey

We use the library [Apscheduler](https://apscheduler.readthedocs.io/en/3.x/) to create a job every 2 hours who will scan the UPLOAD_DIR and compress the directory who hasn't been modified for 2 hours