### PR TITLE
Fix #310 limiter carte suisse dans theme

### DIFF
--- a/backend/app/api/router/config.py
+++ b/backend/app/api/router/config.py
@@ -12,7 +12,7 @@ from app.schemas.placeOfInterest import PlaceOfInterestIn
 from app.schemas.theme_config import LogoUploadPayload, ThemeConfig
 from app.schemas.user import Role, UserPublic
 from app.services.config_service import handle_logo_data_url
-from app.services.geo_service import ALL_LAYERS, get_geo_by_year_selective
+from app.services.geo_service import get_geo_by_canton_preview
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -141,18 +141,17 @@ async def theme_map_preview(
     Retourne les données GeoJSON nécessaires à la preview de la carte
     dans la page de configuration du thème.
 
-    On prend la dernière année disponible côté géo.
+    Pour éviter de charger toute la Suisse dans une simple preview,
+    on limite volontairement la réponse au canton de Vaud.
     """
     ensure_admin(current)
 
-    latest_year = None
-
-    bundle = await get_geo_by_year_selective(
+    bundle = await get_geo_by_canton_preview(
         db,
-        latest_year,
-        layers=set(ALL_LAYERS),
-        clear_others=True,
+        canton_ofs_id=22,
+        requested_year=None,
     )
+
     data = bundle.model_dump()
 
     return {

--- a/backend/app/services/geo_service.py
+++ b/backend/app/services/geo_service.py
@@ -14,7 +14,7 @@ from app.models.lake import Lake
 from app.models.lake_map import LakeMap
 from app.schemas.geo import Feature, FeatureCollection, GeoBundle, Geometry, YearMeta
 from geoalchemy2 import functions as geofunc
-from sqlalchemy import func, select
+from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 
@@ -174,3 +174,144 @@ async def get_geo_by_year_selective(
         bundle_kwargs["communes"] = communes_fc
 
     return GeoBundle(**bundle_kwargs)
+
+
+THEME_MAP_PREVIEW_CANTON_OFS_ID = 22  # Vaud
+
+
+async def get_geo_by_canton_preview(
+    session: AsyncSession,
+    canton_ofs_id: int = THEME_MAP_PREVIEW_CANTON_OFS_ID,
+    requested_year: Optional[int] = None,
+) -> GeoBundle:
+    """
+    Retourne une preview GeoJSON limitée à un seul canton.
+
+    Pour la preview du thème, on ne charge pas toute la Suisse :
+    - canton sélectionné
+    - districts du canton
+    - communes du canton
+    - lacs du canton
+
+    Par défaut, canton_ofs_id=22 correspond au canton de Vaud.
+    """
+    y_req = int(requested_year or date.today().year)
+
+    canton_uid = (await session.execute(select(Canton.uid).where(Canton.ofs_id == canton_ofs_id))).scalar_one_or_none()
+
+    if canton_uid is None:
+        return GeoBundle(
+            year=YearMeta(
+                requested=y_req,
+                country=None,
+                lakes=None,
+                cantons=None,
+                districts=None,
+            ),
+            country=None,
+            lakes=None,
+            cantons=FeatureCollection(features=[]),
+            districts=FeatureCollection(features=[]),
+            communes=FeatureCollection(features=[]),
+        )
+
+    y_cantons = await _max_year_leq(session, CantonMap, y_req)
+    y_districts = await _max_year_leq(session, DistrictMap, y_req)
+    y_communes = await _max_year_leq(session, CommuneMap, y_req)
+    y_lakes = await _max_year_leq(session, LakeMap, y_req)
+
+    canton_fc = FeatureCollection(features=[])
+    districts_fc = FeatureCollection(features=[])
+    communes_fc = FeatureCollection(features=[])
+    lakes_fc = FeatureCollection(features=[])
+
+    if y_cantons is not None:
+        canton_fc = await _features_from_stmt(
+            session,
+            select(
+                geofunc.ST_AsGeoJSON(CantonMap.geometry, maxdecimaldigits=5).label("geojson"),
+                Canton.uid.label("uid"),
+                Canton.code.label("code"),
+                Canton.name.label("name"),
+            )
+            .join(CantonMap.canton)
+            .where(
+                CantonMap.year == y_cantons,
+                Canton.uid == canton_uid,
+            ),
+            ("uid", "code", "name"),
+        )
+
+    if y_districts is not None:
+        districts_fc = await _features_from_stmt(
+            session,
+            select(
+                geofunc.ST_AsGeoJSON(DistrictMap.geometry, maxdecimaldigits=5).label("geojson"),
+                District.uid.label("uid"),
+                District.name.label("name"),
+                District.code.label("code"),
+            )
+            .join(DistrictMap.district)
+            .where(
+                DistrictMap.year == y_districts,
+                District.canton_uid == canton_uid,
+            ),
+            ("uid", "name", "code"),
+        )
+
+    if y_communes is not None:
+        communes_fc = await _features_from_stmt(
+            session,
+            select(
+                geofunc.ST_AsGeoJSON(CommuneMap.geometry, maxdecimaldigits=5).label("geojson"),
+                Commune.uid.label("uid"),
+                Commune.name.label("name"),
+                Commune.code.label("code"),
+            )
+            .join(CommuneMap.commune)
+            .join(District, Commune.district_uid == District.uid)
+            .where(
+                CommuneMap.year == y_communes,
+                District.canton_uid == canton_uid,
+            ),
+            ("uid", "name", "code"),
+        )
+
+    if y_lakes is not None and y_cantons is not None:
+        lakes_fc = await _features_from_stmt(
+            session,
+            select(
+                geofunc.ST_AsGeoJSON(LakeMap.geometry, maxdecimaldigits=5).label("geojson"),
+                Lake.uid.label("uid"),
+                Lake.name.label("name"),
+                Lake.code.label("code"),
+            )
+            .join(LakeMap.lake)
+            .join(
+                CantonMap,
+                and_(
+                    CantonMap.year == y_cantons,
+                    CantonMap.canton_uid == canton_uid,
+                ),
+            )
+            .where(
+                LakeMap.year == y_lakes,
+                geofunc.ST_Intersects(LakeMap.geometry, CantonMap.geometry),
+            ),
+            ("uid", "name", "code"),
+        )
+
+    return GeoBundle(
+        year=YearMeta(
+            requested=y_req,
+            country=None,
+            lakes=y_lakes,
+            cantons=y_cantons,
+            districts=y_districts,
+        ),
+        country=None,
+        lakes=lakes_fc,
+        cantons=canton_fc,
+        districts=districts_fc,
+        communes=communes_fc,
+    )

--- a/frontend/src/features/admin/components/theme/MapPreviewPanel.tsx
+++ b/frontend/src/features/admin/components/theme/MapPreviewPanel.tsx
@@ -64,7 +64,7 @@ export default function MapPreviewPanel({
   React.useEffect(() => {
     let cancelled = false;
 
-    const run = async () => {
+    async function run() {
       try {
         setLoading(true);
         setError(null);
@@ -76,22 +76,23 @@ export default function MapPreviewPanel({
         }
       } catch (e) {
         console.error(e);
+
         if (!cancelled) {
-          setError(t("admin.config.themeConfigPage.loadError"));
+          setError("loadError");
         }
       } finally {
         if (!cancelled) {
           setLoading(false);
         }
       }
-    };
+    }
 
     run();
 
     return () => {
       cancelled = true;
     };
-  }, [t]);
+  }, []);
 
   const mapKey = React.useMemo(() => {
     return [
@@ -121,7 +122,7 @@ export default function MapPreviewPanel({
 
         {!loading && error && (
           <div className="flex h-full items-center justify-center px-4 text-center text-sm opacity-70">
-            {error}
+            {t("admin.config.themeConfigPage.loadError")}
           </div>
         )}
 

--- a/frontend/src/services/config.ts
+++ b/frontend/src/services/config.ts
@@ -89,18 +89,41 @@ type ApiEnvelope<T> = {
   data: T;
 };
 
+let themeMapPreviewCache: ThemeMapPreviewBundle | null = null;
+let themeMapPreviewPromise: Promise<ThemeMapPreviewBundle> | null = null;
+
 export async function fetchThemeMapPreview(): Promise<ThemeMapPreviewBundle> {
-  const res = await apiFetch<ApiEnvelope<ThemeMapPreviewBundle>>(
+  if (themeMapPreviewCache) {
+    return themeMapPreviewCache;
+  }
+
+  if (themeMapPreviewPromise) {
+    return themeMapPreviewPromise;
+  }
+
+  themeMapPreviewPromise = apiFetch<ApiEnvelope<ThemeMapPreviewBundle>>(
     "/config/theme/map-preview",
     {
       method: "GET",
       auth: true,
     }
-  );
+  )
+    .then((res) => {
+      if (!res.success) {
+        throw new Error(res.detail || "Failed to load theme map preview");
+      }
 
-  if (!res.success) {
-    throw new Error(res.detail || "Failed to load theme map preview");
-  }
+      themeMapPreviewCache = res.data;
+      return res.data;
+    })
+    .finally(() => {
+      themeMapPreviewPromise = null;
+    });
 
-  return res.data;
+  return themeMapPreviewPromise;
+}
+
+export function clearThemeMapPreviewCache() {
+  themeMapPreviewCache = null;
+  themeMapPreviewPromise = null;
 }


### PR DESCRIPTION
### Objectif

Cette PR optimise la preview de carte utilisée dans la configuration du thème.

L’objectif est d’éviter de charger toute la carte de la Suisse pour une simple preview visuelle des couleurs de carte.

La preview est désormais limitée au canton de Vaud, avec ses districts, ses communes et les lacs qui intersectent le canton.

Cette PR améliore aussi le chargement frontend afin que les previews `light` et `dark` réutilisent les mêmes données GeoJSON au lieu de déclencher deux appels API séparés.

---

### Changements principaux

#### Limitation de la preview de carte au canton de Vaud
- Remplacement du chargement complet de la Suisse par une preview limitée à un seul canton.
- Ajout d’une logique backend dédiée à la preview de thème.
- Le canton utilisé pour la preview est identifié via son `ofs_id`.
- Le canton de Vaud est utilisé comme canton par défaut avec `ofs_id = 22`.

---

#### Récupération des districts et communes du canton
- Ajout du filtrage des districts à partir du `canton_uid`.
- Ajout du filtrage des communes via leur district.
- La preview affiche uniquement :
  - le canton sélectionné
  - les districts du canton
  - les communes appartenant aux districts du canton
- Cette approche évite de charger les géométries de tous les cantons, districts et communes de Suisse.

---

#### Ajout des lacs liés au canton
- Ajout des lacs dans la preview de carte limitée au canton.
- Les lacs sont récupérés par intersection géographique avec la géométrie du canton.
- Cette logique permet d’afficher les lacs pertinents même s’ils ne sont pas reliés directement à un canton en base de données.
- Les lacs sont retournés dans la même réponse que les autres couches GeoJSON.

---

#### Conservation du endpoint existant
- Conservation de la route existante `GET /config/theme/map-preview`.
- Le frontend continue d’utiliser le même endpoint.
- Le comportement interne de la route est modifié pour retourner une réponse plus légère.
- La réponse conserve la structure existante :
  - `year`
  - `country`
  - `lakes`
  - `cantons`
  - `districts`
  - `communes`

---

#### Réduction du volume de données GeoJSON
- Suppression du chargement de toutes les couches géographiques nationales pour la preview de thème.
- La couche `country` n’est plus nécessaire pour cette preview ciblée.
- Les données retournées sont limitées aux couches utiles pour visualiser les couleurs de la carte.
- Cette modification réduit la taille de la réponse API et améliore les performances de chargement.

---

#### Mutualisation du chargement frontend
- Ajout d’un cache côté frontend pour les données de preview de carte.
- Les previews `light` et `dark` réutilisent les mêmes données GeoJSON.
- Si une preview lance déjà le chargement, l’autre réutilise la même `Promise`.
- Si les données sont déjà chargées, elles sont retournées depuis le cache.
- Cette modification évite de faire deux appels API identiques pour afficher les deux variantes de thème.

---

#### Conservation des deux previews visuelles
- Les previews `light` et `dark` restent affichées séparément.
- Chaque preview continue d’utiliser ses propres couleurs :
  - communes
  - districts
  - canton
  - lacs
  - arrière-plan
- Seules les données géographiques sont partagées entre les deux previews.
- Le composant existant reste globalement inchangé côté affichage.

---

#### Amélioration de la robustesse de l’affichage
- Ajout d’une vérification de présence réelle de données GeoJSON avant d’afficher la carte.
- La preview ne dépend plus de la présence de la couche `country`.
- La carte peut s’afficher correctement avec uniquement :
  - `cantons`
  - `districts`
  - `communes`
  - `lakes`
- Le loader reste disponible pendant le chargement initial des données.

---

### Résultat

- La preview de carte ne charge plus toute la Suisse.
- La preview est limitée au canton de Vaud.
- Les districts et communes affichés correspondent uniquement au canton ciblé.
- Les lacs pertinents sont affichés grâce à une intersection géographique.
- Les deux previews `light` et `dark` conservent leur rendu séparé.
- Un seul appel API est nécessaire pour charger les données GeoJSON.
- La réponse API est plus légère.
- Le rendu de la page de configuration du thème est plus performant.
- Le comportement existant de personnalisation des couleurs est conservé.

---

### Images
<img width="1721" height="753" alt="Capture d’écran 2026-07-09 à 11 43 29" src="https://github.com/user-attachments/assets/efa7dffa-b901-44e0-a4da-8227367988d2" />