### PR TITLE
Fix #327 modification .env et variable docker

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,4 +1,6 @@
 # Database
+# Pour Docker:
+# DB_HOST=db
 DB_HOST=localhost
 DB_PORT=5432
 DB_NAME=datahub
@@ -6,10 +8,14 @@ DB_USER=postgres
 DB_PASSWORD=postgres
 
 # Backend
+# Pour Docker:
+# BACKEND_HOST=0.0.0.0
 BACKEND_HOST=localhost
 BACKEND_PORT=8000
 
 # Frontend
+# Pour Docker:
+# FRONTEND_HOST=0.0.0.0
 FRONTEND_HOST=localhost
 FRONTEND_PORT=3210
 
@@ -26,6 +32,9 @@ COOKIE_SECURE=False
 COOKIE_SAMESITE=lax
 
 # CORS and API
+# Pour Docker:
+# CORS_ORIGINS=http://localhost:$FRONTEND_PORT
+# API_URL=http://localhost:$BACKEND_PORT
 CORS_ORIGINS=http://$FRONTEND_HOST:$FRONTEND_PORT
 API_URL=http://$BACKEND_HOST:$BACKEND_PORT
 VITE_API_BASE_URL=$API_URL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       POSTGRES_USER: ${DB_USER}
       POSTGRES_PASSWORD: ${DB_PASSWORD}
     ports:
-      - "5432:5432"  # only for dev
+      - "${DB_PORT}:${DB_PORT}"  # only for dev
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:
@@ -28,8 +28,10 @@ services:
     # depends_on:
     #   db:
     #     condition: service_healthy   # commenter si depends voulue ou pas entre les service api et db
+    command:
+      ["uvicorn", "app.main:app", "--host", "${BACKEND_HOST}", "--port", "${BACKEND_PORT}", "--reload"]
     ports:
-      - "8000:8000" # only for dev
+      - "${BACKEND_PORT}:${BACKEND_PORT}" # only for dev
     working_dir: /app/backend
     volumes:
       - ./backend:/app/backend:z
@@ -39,8 +41,10 @@ services:
     build:
       context: .
       dockerfile: docker/frontend/Dockerfile
+    command:
+      ["npm", "run", "dev", "--", "--host", "${FRONTEND_HOST}", "--port", "${FRONTEND_PORT}"]
     ports:
-      - "3000:3000"
+      - "${FRONTEND_PORT}:${FRONTEND_PORT}"
     env_file:
       - .env
     volumes:

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -14,7 +14,3 @@ COPY requirements.txt /app/
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY ./backend /app
-
-EXPOSE 8000
-
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -4,5 +4,3 @@ WORKDIR /app
 COPY frontend/package*.json ./
 RUN npm ci
 COPY frontend/ .
-EXPOSE 3000
-CMD ["npm","run","dev","--","--host","0.0.0.0","--port","3000"]


### PR DESCRIPTION
## Objectif

Déplacer les valeurs Docker codées en dur vers le fichier `.env`.

### Changements principaux

- Remplacement des ports Docker codés en dur par les valeurs définies dans `.env`.
- Remplacement des adresses d'écoute (`host`) du backend et du frontend par les variables du fichier `.env`.
- Mise à jour de `docker-compose.yml` afin d'utiliser ces variables pour les commandes de lancement et le mapping des ports.
- Suppression des instructions `CMD` et `EXPOSE` codées en dur dans les Dockerfiles du backend et du frontend, la configuration étant désormais gérée par Docker Compose.

### Résultat

- Centralise la configuration Docker dans le fichier `.env`.
- Permet de modifier les ports et les adresses d'écoute sans toucher aux fichiers Docker.
- Améliore la maintenabilité et facilite la configuration selon les différents environnements.