### PR TITLE
Fix #333 mettre point des ville au dessus des reponses

### DIFF
--- a/frontend/src/components/map/PlaceOfInterestMarkers.tsx
+++ b/frontend/src/components/map/PlaceOfInterestMarkers.tsx
@@ -15,7 +15,7 @@ export default function PlaceOfInterestMarkers({ placeOfInterest }: Props) {
 
   return (
     // zIndex < 650 (tooltipPane) pour que les tooltips passent par-dessus
-    <Pane name="placeOfInterest" style={{ zIndex: 675 }}>
+    <Pane name="placeOfInterest" style={{ zIndex: 725 }}>
       {placeOfInterest.map((c) => (
         <CircleMarker
           key={c.code}

--- a/frontend/src/components/map/PlaceOfInterestMarkers.tsx
+++ b/frontend/src/components/map/PlaceOfInterestMarkers.tsx
@@ -15,7 +15,7 @@ export default function PlaceOfInterestMarkers({ placeOfInterest }: Props) {
 
   return (
     // zIndex < 650 (tooltipPane) pour que les tooltips passent par-dessus
-    <Pane name="placeOfInterest" style={{ zIndex: 625 }}>
+    <Pane name="placeOfInterest" style={{ zIndex: 675 }}>
       {placeOfInterest.map((c) => (
         <CircleMarker
           key={c.code}


### PR DESCRIPTION
### Objectif

Cette PR modifie le **z-index** afin que les icônes des lieux d'intérêt apparaissent au-dessus des réponses affichées sur la carte.

---

### Images
<img width="1717" height="738" alt="Capture d’écran 2026-07-22 à 15 39 09" src="https://github.com/user-attachments/assets/faac7d66-adeb-451a-bf1f-97f21d03a43b" />
