### PR TITLE
Fix #330 : Launch app without survey data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ DB_SERVICE = db
 FRONT_SERVICE = frontend
 INIT_SERVICE = schema_db_init
 INIT_DEMO_SERVICE = schema_db_init_demo
+INIT_EMPTY_SERVICE = schema_db_init_empty
 API_SERVICE = api
 
 # build service DB (db) and api and front + initdb, then display the Postgres logs.
@@ -79,6 +80,13 @@ docker_demo:
 	$(COMPOSE) up -d --build $(INIT_DEMO_SERVICE) $(FRONT_SERVICE)
 	@echo "✅  Services started"
 	$(COMPOSE) logs -f $(INIT_DEMO_SERVICE) $(API_SERVICE) $(FRONT_SERVICE)
+
+docker_empty:
+	$(COMPOSE) up -d --build $(DB_SERVICE) $(API_SERVICE)
+	$(COMPOSE) up -d --build $(INIT_EMPTY_SERVICE) $(FRONT_SERVICE)
+	@echo "✅  Services started"
+	$(COMPOSE) logs -f $(INIT_EMPTY_SERVICE) $(API_SERVICE) $(FRONT_SERVICE)
+
 
 # Stop the project's Docker services and delete the containers + volumes
 docker_clean:

--- a/backend/app/script/init_db_async.py
+++ b/backend/app/script/init_db_async.py
@@ -17,7 +17,7 @@ from app.script.populate_geo_db import populate_async_geo
 logger = logging.getLogger(__name__)
 
 
-async def create_schema(is_demo: bool, delete_force: bool) -> None:
+async def create_schema(is_demo: bool, delete_force: bool, empty_survey: bool) -> None:
     try:
         await ensure_extensions()
     except Exception as e:
@@ -55,6 +55,10 @@ async def create_schema(is_demo: bool, delete_force: bool) -> None:
     await populate_config_if_empty()
     logger.info("Config table initialized (if empty).")
 
+    if empty_survey:
+        logger.info("Database populated with no survey and geo data")
+        return
+
     if is_demo:
         await populate_demo_db()
         logger.info("Database populated successfully with demo data.")
@@ -72,6 +76,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("-d", dest="demo", action="store_true")
     parser.add_argument("-f", dest="force", action="store_true")
+    parser.add_argument("-e", dest="empty", action="store_true")
     args = parser.parse_args()
     configure_logging()
-    asyncio.run(create_schema(args.demo, args.force))
+    asyncio.run(create_schema(args.demo, args.force, args.empty))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,5 +81,20 @@ services:
       - ./backend:/app/backend:z  
     restart: "no"
 
+  schema_db_init_empty:
+    build:
+      context: .
+      dockerfile: docker/backend/Dockerfile
+    env_file:
+      - .env
+    depends_on:
+      db:
+        condition: service_healthy
+    command: ["python", "-m", "app.script.init_db_async", "-f", "-e"]
+    working_dir: /app/backend
+    volumes:
+      - ./backend:/app/backend:z  
+    restart: "no"
+
 volumes:
   pgdata:


### PR DESCRIPTION
This pr aims to add the possibility to run the application with an empty database to test the import of new survey via the backend