### PR TITLE
Fix #338 modifier l'affichage des lieux d intéret

### DIFF
--- a/backend/app/api/router/geoSearch.py
+++ b/backend/app/api/router/geoSearch.py
@@ -3,7 +3,7 @@ from typing import Literal
 
 from app.api.dependencies import get_current_user
 from app.db import get_db
-from app.repositories.geo_search_repo import get_geo_point, suggest_geo_locations
+from app.repositories.geo_search_repo import build_geo_names, get_geo_point, resolve_geo_name, suggest_geo_locations
 from app.schemas.placeOfInterest import (
     GeoPointResponse,
     GeoSuggestionResponse,
@@ -86,6 +86,7 @@ async def geo_point(
 @router.get("/suggest/public", response_model=PlaceOfInterestSuggestResponse)
 async def suggest_geo_public(
     q: str = Query(..., min_length=3, max_length=100),
+    lang: str = Query("en", description="ISO code de langue, ex: fr, de, it, ro, en"),
     limit: int = Query(50, ge=1, le=50),
     db: AsyncSession = Depends(get_db),
 ):
@@ -129,12 +130,19 @@ async def suggest_geo_public(
         if not default_name:
             continue
 
+        localized_name = resolve_geo_name(row, lang)
+
+        if not localized_name:
+            continue
+
         place_of_interest.append(
             PlaceOfInterestSuggestOut(
                 uid=row["uid"],
                 type=row["type"],
                 code=row["code"],
+                name=localized_name,
                 default_name=default_name,
+                names=build_geo_names(row),
                 pos=(float(pos[0]), float(pos[1])),
             )
         )

--- a/backend/app/repositories/geo_search_repo.py
+++ b/backend/app/repositories/geo_search_repo.py
@@ -13,6 +13,47 @@ from sqlalchemy.ext.asyncio import AsyncSession
 GeoType = Literal["commune", "district", "canton"]
 
 
+LANG_FIELD_MAP = {
+    "fr": "name_fr",
+    "de": "name_de",
+    "it": "name_it",
+    "ro": "name_ro",
+    "en": "name_en",
+}
+
+
+def normalize_geo_language(lang: str | None) -> str:
+    return (lang or "").strip().lower().replace("_", "-").split("-")[0] or "en"
+
+
+def resolve_geo_name(item: dict, lang: str | None) -> str:
+    normalized_lang = normalize_geo_language(lang)
+    field_name = LANG_FIELD_MAP.get(normalized_lang, "name_en")
+    localized_name = item.get(field_name)
+    if isinstance(localized_name, str) and localized_name.strip():
+        return localized_name.strip()
+    default_name = item.get("name")
+    if isinstance(default_name, str) and default_name.strip():
+        return default_name.strip()
+
+    code = item.get("code")
+
+    if isinstance(code, str):
+        return code
+
+    return ""
+
+
+def build_geo_names(item: dict) -> dict:
+    return {
+        "fr": item.get("name_fr"),
+        "de": item.get("name_de"),
+        "it": item.get("name_it"),
+        "ro": item.get("name_ro"),
+        "en": item.get("name_en"),
+    }
+
+
 def normalize_search_text(value: Optional[str]) -> str:
     if not value:
         return ""

--- a/backend/app/repositories/placeOfInterest_repo.py
+++ b/backend/app/repositories/placeOfInterest_repo.py
@@ -3,8 +3,11 @@ import re
 import unicodedata
 
 
+from app.models.canton import Canton
+from app.models.commune import Commune
+from app.models.district import District
 from app.models.placeOfInterest import PlaceOfInterest
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 
@@ -15,6 +18,25 @@ LANG_FIELD_MAP = {
     "ro": "name_ro",
     "en": "name_en",
 }
+
+
+async def resolve_place_of_interest_geo_type(db: AsyncSession, code: str) -> str:
+    commune_uid = await db.scalar(select(Commune.uid).where(Commune.code == code).limit(1))
+
+    if commune_uid is not None:
+        return "commune"
+
+    district_uid = await db.scalar(select(District.uid).where(District.code == code).limit(1))
+
+    if district_uid is not None:
+        return "district"
+
+    canton_uid = await db.scalar(select(Canton.uid).where(Canton.code == code).limit(1))
+
+    if canton_uid is not None:
+        return "canton"
+
+    return "commune"
 
 
 def placeOfInterest_to_dict(c: PlaceOfInterest) -> dict:
@@ -85,7 +107,11 @@ def slugify(s: str) -> str:
     return s or "placeOfInterest"
 
 
-def placeOfInterest_to_client_dict(c: PlaceOfInterest, lang: str) -> dict:
+def placeOfInterest_to_client_dict(
+    c: PlaceOfInterest,
+    lang: str,
+    geo_type: str,
+) -> dict:
     # lang peut être "fr-CH", "de-CH"... on garde juste la partie avant le "-"
     base_lang = (lang or "").split("-")[0].lower() or "en"
 
@@ -102,6 +128,7 @@ def placeOfInterest_to_client_dict(c: PlaceOfInterest, lang: str) -> dict:
         "code": c.code,
         "name": label,
         "pos": list(c.pos),
+        "geo_type": geo_type,
     }
 
 
@@ -109,4 +136,9 @@ async def list_placeOfInterest_for_lang(db: AsyncSession, lang: str) -> List[dic
     stmt = select(PlaceOfInterest).where(PlaceOfInterest.active == True).order_by(PlaceOfInterest.default_name.asc())
     res = await db.execute(stmt)
     placeOfInterest = res.scalars().all()
-    return [placeOfInterest_to_client_dict(c, lang) for c in placeOfInterest]
+    result: List[dict] = []
+    for c in placeOfInterest:
+        geo_type = await resolve_place_of_interest_geo_type(db, c.code)
+        result.append(placeOfInterest_to_client_dict(c, lang, geo_type))
+
+    return result

--- a/backend/app/schemas/placeOfInterest.py
+++ b/backend/app/schemas/placeOfInterest.py
@@ -98,6 +98,14 @@ class GeoPointResponse(BaseModel):
     data: Optional[GeoPointOut] = None
 
 
+class LocalizedPlaceNamesOut(BaseModel):
+    fr: str | None = None
+    de: str | None = None
+    it: str | None = None
+    ro: str | None = None
+    en: str | None = None
+
+
 class PlaceOfInterestSuggestOut(BaseModel):
     """
     Schéma pour la suggestion publique utilisée par la carte.
@@ -111,7 +119,9 @@ class PlaceOfInterestSuggestOut(BaseModel):
     uid: int
     type: GeoSuggestionType
     code: str
+    name: str
     default_name: str
+    names: LocalizedPlaceNamesOut
     pos: Tuple[float, float] = Field(..., description="[lat, lon]")
 
 

--- a/backend/app/schemas/placeOfInterest.py
+++ b/backend/app/schemas/placeOfInterest.py
@@ -40,6 +40,11 @@ class PlaceOfInterestClientOut(BaseModel):
     code: str
     name: str
     pos: Tuple[float, float]
+    geo_type: Literal[
+        "commune",
+        "district",
+        "canton",
+    ]
 
 
 class PlaceOfInterestIn(PlaceOfInterestBase):

--- a/frontend/src/components/GeoJsonMap.tsx
+++ b/frontend/src/components/GeoJsonMap.tsx
@@ -569,7 +569,11 @@ export default function GeoJsonMap({
           </>
         )}
         {/* Points villes et labels */}
-        <PlaceOfInterestLayer />
+        <PlaceOfInterestLayer
+          communes={communes}
+          districts={districts}
+          cantons={cantons}
+        />
       </MapContainer>
 
       {/* Alerte d’erreur de chargement géo */}

--- a/frontend/src/components/map/PlaceOfInterestLayer.tsx
+++ b/frontend/src/components/map/PlaceOfInterestLayer.tsx
@@ -4,6 +4,7 @@ import PlaceOfInterestMarkers from "@/components/map/PlaceOfInterestMarkers";
 import { usePlaceOfInterestMarkers } from "@/features/geo/hooks/usePlaceOfInterestMarkers";
 import PlaceOfInterestMenuModal from "@/components/map/PlaceOfInterestMenuModal";
 import { useTheme } from "@/theme/useTheme";
+import { normalizeGeoLanguage } from "@/features/geo/geoLanguage";
 
 const CUSTOM_OFFSET_PX = 160;
 
@@ -11,8 +12,11 @@ export default function PlaceOfInterestLayer() {
   const { t, i18n } = useTranslation();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
-  const currentLang =
-    i18n.language || window.localStorage.getItem("i18nextLng") || "en";
+  const currentLang = normalizeGeoLanguage(
+    i18n.resolvedLanguage ||
+      i18n.language ||
+      localStorage.getItem("i18nextLng")
+  );
 
   const {
     placeOfInterest,
@@ -97,6 +101,7 @@ export default function PlaceOfInterestLayer() {
       <PlaceOfInterestMenuModal
         isOpen={isMenuOpen}
         onClose={() => setIsMenuOpen(false)}
+        lang={currentLang}
         backendPlaceOfInterest={backendPlaceOfInterest}
         extraPlaceOfInterest={extraPlaceOfInterest}
         hideAllBackend={hideAllBackend}

--- a/frontend/src/components/map/PlaceOfInterestLayer.tsx
+++ b/frontend/src/components/map/PlaceOfInterestLayer.tsx
@@ -5,10 +5,29 @@ import { usePlaceOfInterestMarkers } from "@/features/geo/hooks/usePlaceOfIntere
 import PlaceOfInterestMenuModal from "@/components/map/PlaceOfInterestMenuModal";
 import { useTheme } from "@/theme/useTheme";
 import { normalizeGeoLanguage } from "@/features/geo/geoLanguage";
+import type { FeatureCollection, GeoFeatureProperties } from "@/features/geo/geoApi";
 
 const CUSTOM_OFFSET_PX = 160;
 
-export default function PlaceOfInterestLayer() {
+type Props = {
+  communes?: FeatureCollection<
+    GeoFeatureProperties
+  > | null;
+
+  districts?: FeatureCollection<
+    GeoFeatureProperties
+  > | null;
+
+  cantons?: FeatureCollection<
+    GeoFeatureProperties
+  > | null;
+};
+
+export default function PlaceOfInterestLayer({
+  communes,
+  districts,
+  cantons,
+}: Props) {
   const { t, i18n } = useTranslation();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
@@ -95,7 +114,12 @@ export default function PlaceOfInterestLayer() {
       </div>
 
       {/* Marqueurs de villes sur la carte */}
-      <PlaceOfInterestMarkers placeOfInterest={placeOfInterest} />
+      <PlaceOfInterestMarkers
+        placeOfInterest={placeOfInterest}
+        communes={communes}
+        districts={districts}
+        cantons={cantons}
+      />
 
       {/* Modale de gestion des villes */}
       <PlaceOfInterestMenuModal

--- a/frontend/src/components/map/PlaceOfInterestMarkers.tsx
+++ b/frontend/src/components/map/PlaceOfInterestMarkers.tsx
@@ -1,32 +1,296 @@
 // Marqueurs des villes repères : place quelques grandes villes suisses
 // et affiche leur nom au survol (ou au clic sur mobile/tactile).
-import { CircleMarker, Tooltip, Pane } from "react-leaflet";
-import type { LatLngExpression } from "leaflet";
-import type { PlaceOfInterestMarker } from "@/features/geo/hooks/usePlaceOfInterestMarkers";
+import {CircleMarker, GeoJSON, Pane, Tooltip} from "react-leaflet";
+import type {LatLngExpression, PathOptions} from "leaflet";
+import type {Feature, FeatureCollection, GeoFeatureProperties} from "@/features/geo/geoApi";
+import type {PlaceOfInterestMarker} from "@/features/geo/hooks/usePlaceOfInterestMarkers";
 import { hexToRgba } from "@/utils/color";
 import { useTheme } from "@/theme/useTheme";
 
+type GeoCollection = FeatureCollection<GeoFeatureProperties>;
+type GeoFeature = Feature<GeoFeatureProperties>;
 type Props = {
   placeOfInterest: PlaceOfInterestMarker[];
+  communes?: GeoCollection | null;
+  districts?: GeoCollection | null;
+  cantons?: GeoCollection | null;
 };
 
-export default function PlaceOfInterestMarkers({ placeOfInterest }: Props) {
-  const { textColor, background, borderColor } = useTheme();
+type AreaPlaceOfInterest = {
+  place: PlaceOfInterestMarker;
+  feature: GeoFeature;
+};
+
+const normalizeGeoCode = (
+  value: unknown
+): string =>
+  String(value ?? "")
+    .trim()
+    .toLowerCase();
+
+const getLocalUid = (
+  place: PlaceOfInterestMarker
+): number | null => {
+  if (place.source !== "local") {
+    return null;
+  }
+
+  const match = place.code.match(
+    /^local-(commune|district|canton)-(\d+)$/
+  );
+
+  if (!match) {
+    return null;
+  }
+
+  const uid = Number(match[2]);
+
+  return Number.isFinite(uid)
+    ? uid
+    : null;
+};
+
+const findGeoFeature = (
+  collection: GeoCollection | null | undefined,
+  place: PlaceOfInterestMarker
+): GeoFeature | undefined => {
+  if (!collection) {
+    return undefined;
+  }
+
+  /*
+   * Nouveau stockage :
+   * comparaison par vrai code géographique.
+   */
+  if (place.geoCode) {
+    const normalizedCode = normalizeGeoCode(place.geoCode);
+
+    const featureByCode =
+      collection.features.find(
+        (feature) =>
+          normalizeGeoCode(
+            feature.properties?.code
+          ) === normalizedCode
+      );
+
+    if (featureByCode) {
+      return featureByCode;
+    }
+  }
+
+  /*
+   * Compatibilité avec les anciens POI locaux
+   * qui contiennent uniquement :
+   *
+   * local-district-117
+   * local-canton-8
+   */
+  const localUid =
+    getLocalUid(place);
+
+  if (localUid === null) {
+    return undefined;
+  }
+
+  return collection.features.find(
+    (feature) =>
+      Number(
+        feature.properties?.uid
+      ) === localUid
+  );
+};
+
+export default function PlaceOfInterestMarkers({
+  placeOfInterest,
+  communes: _communes,
+  districts,
+  cantons,
+}: Props) {
+  const {textColor, background, borderColor, cantonColores, districtColores} = useTheme();
+
+  const communePlaces =
+    placeOfInterest.filter(
+      (place) => place.geoType === "commune"
+    );
+
+  const districtPlaces =
+    placeOfInterest
+      .filter(
+        (place) => place.geoType === "district"
+      )
+      .map((place) => ({
+        place,
+        feature: findGeoFeature(
+          districts,
+          place
+        ),
+      }))
+      .filter(
+        (
+          item
+        ): item is AreaPlaceOfInterest =>
+          item.feature !== undefined
+      );
+
+  const cantonPlaces =
+    placeOfInterest
+      .filter(
+        (place) =>
+          place.geoType === "canton"
+      )
+      .map((place) => ({
+        place,
+        feature: findGeoFeature(
+          cantons,
+          place
+        ),
+      }))
+      .filter(
+        (
+          item
+        ): item is AreaPlaceOfInterest =>
+          item.feature !== undefined
+      );
+
+  /*
+   * Fallback :
+   * si un district ou canton n'est pas
+   * retrouvé dans le GeoJSON, il reste
+   * affiché comme point.
+   */
+  const resolvedAreaCodes = new Set([
+    ...districtPlaces.map(
+      ({ place }) => place.code
+    ),
+    ...cantonPlaces.map(
+      ({ place }) => place.code
+    ),
+  ]);
+
+  const pointPlaces =
+    placeOfInterest.filter(
+      (place) =>
+        place.geoType === "commune" ||
+        !resolvedAreaCodes.has(place.code)
+    );
+
+  const districtStyle:
+    PathOptions = {
+      color: districtColores,
+      weight: 4,
+      opacity: 1,
+      fill: false,
+      fillOpacity: 0,
+    };
+
+  const cantonStyle:
+    PathOptions = {
+      color: cantonColores,
+      weight: 5,
+      opacity: 1,
+      fill: false,
+      fillOpacity: 0,
+    };
+
+  const bindAreaTooltip = (
+    place: PlaceOfInterestMarker
+  ) => (
+    _feature: GeoFeature,
+    layer: any
+  ) => {
+    layer.bindTooltip(
+      place.name,
+      {
+        sticky: true,
+        direction: "right",
+        offset: [8, 0],
+        opacity: 1,
+        className: "place-of-interest-area-tooltip",
+      }
+    );
+
+    layer.on({
+      mouseover: () => layer.openTooltip(),
+      mouseout: () => layer.closeTooltip(),
+      click: () => layer.openTooltip(),
+    });
+  };
 
   return (
-    // zIndex < 650 (tooltipPane) pour que les tooltips passent par-dessus
-    <Pane name="placeOfInterest" style={{ zIndex: 625 }}>
-      {placeOfInterest.map((c) => (
-        <CircleMarker
-          key={c.code}
-          center={c.pos as LatLngExpression}
-          radius={5}
-          pathOptions={{
-            color: textColor,
-            weight: 1,
-            fillColor: textColor,
-            fillOpacity: 1,
-          }}
+    <>
+      <style>{`
+        .leaflet-tooltip.place-of-interest-area-tooltip {
+          padding: 2px 6px border-radius: 6px;
+          white-space: nowrap font-size: 12px;
+          font-weight: 600 background: ${background};
+          color: ${textColor} border: 1px solid ${borderColor};
+          box-shadow: 0 1px 2px ${hexToRgba("#111827", 0.1)};
+        }
+
+        .leaflet-tooltip.place-of-interest-area-tooltip::before {
+          display: none;
+        }
+      `}</style>
+
+      <Pane
+        name="placeOfInterestDistricts"
+        style={{ zIndex: 725 }}
+      >
+        {districtPlaces.map(
+          ({ place, feature }) => (
+            <GeoJSON
+              key={place.code}
+              data={feature}
+              pane="placeOfInterestDistricts"
+              style={() =>
+                districtStyle
+              }
+              onEachFeature={
+                bindAreaTooltip(place)
+              }
+            />
+          )
+        )}
+      </Pane>
+
+      <Pane
+        name="placeOfInterestCantons"
+        style={{ zIndex: 726 }}
+      >
+        {cantonPlaces.map(
+          ({ place, feature }) => (
+            <GeoJSON
+              key={place.code}
+              data={feature}
+              pane="placeOfInterestCantons"
+              style={() =>
+                cantonStyle
+              }
+              onEachFeature={
+                bindAreaTooltip(place)
+              }
+            />
+          )
+        )}
+      </Pane>
+
+      <Pane
+        name="placeOfInterestPoints"
+        style={{ zIndex: 725 }}
+      >
+        {pointPlaces.map((c) => (
+          <CircleMarker
+            key={c.code}
+            center={
+              c.pos as LatLngExpression
+            }
+            radius={5}
+            pathOptions={{
+              color: textColor,
+              weight: 1,
+              fillColor: textColor,
+              fillOpacity: 1,
+            }}
           eventHandlers={{
             mouseover: (e) => e.target.openTooltip(),
             mouseout: (e) => e.target.closeTooltip(),
@@ -65,5 +329,6 @@ export default function PlaceOfInterestMarkers({ placeOfInterest }: Props) {
         </CircleMarker>
       ))}
     </Pane>
+    </>
   );
 }

--- a/frontend/src/components/map/PlaceOfInterestMenuModal.tsx
+++ b/frontend/src/components/map/PlaceOfInterestMenuModal.tsx
@@ -8,6 +8,7 @@ import { useTheme } from "@/theme/useTheme";
 type Props = {
   isOpen: boolean;
   onClose: () => void;
+  lang: string;
 
   backendPlaceOfInterest: PlaceOfInterestMarker[];
   extraPlaceOfInterest: PlaceOfInterestMarker[];
@@ -23,6 +24,7 @@ type Props = {
 export default function PlaceOfInterestMenuModal({
   isOpen,
   onClose,
+  lang,
   backendPlaceOfInterest,
   extraPlaceOfInterest,
   hideAllBackend,
@@ -79,7 +81,7 @@ export default function PlaceOfInterestMenuModal({
     setError(null);
 
     communesApi
-      .suggest(value.trim(), ctrl.signal, 10)
+      .suggest(value.trim(), lang, ctrl.signal, 10)
       .then((res) => {
         if (!res.success) {
           setError(res.detail || t("map.errors.failedToFetchSuggestions"));
@@ -100,10 +102,16 @@ export default function PlaceOfInterestMenuModal({
 
   const handleAddSuggestion = (s: PlaceOfInterestSuggestDTO) => {
     const code = `local-${s.type}-${s.uid}`;
+    const fallbackName = s.name?.trim() || s.default_name?.trim();
+    if (!fallbackName) {
+      setError(t("map.errors.failedToFetchSuggestions"));
+      return;
+    }
 
     addExtraPlaceOfInterest({
       code,
-      name: s.default_name,
+      name: fallbackName,
+      names: s.names,
       pos: s.pos,
     });
 
@@ -288,7 +296,7 @@ export default function PlaceOfInterestMenuModal({
                     } as React.CSSProperties
                   }
                 >
-                  <span className="truncate font-medium">{s.default_name}</span>
+                  <span className="truncate font-medium">{s.name || s.default_name}</span>
 
                   <span
                     className="shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-medium"

--- a/frontend/src/components/map/PlaceOfInterestMenuModal.tsx
+++ b/frontend/src/components/map/PlaceOfInterestMenuModal.tsx
@@ -101,6 +101,14 @@ export default function PlaceOfInterestMenuModal({
   };
 
   const handleAddSuggestion = (s: PlaceOfInterestSuggestDTO) => {
+    console.log("Suggestion complète :", s);
+    console.log("uid :", s.uid);
+    console.log("code :", s.code);
+    console.log("type :", s.type);
+    console.log("name :", s.name);
+    console.log("default_name :", s.default_name);
+    console.log("pos :", s.pos);
+    console.log("names :", s.names);
     const code = `local-${s.type}-${s.uid}`;
     const fallbackName = s.name?.trim() || s.default_name?.trim();
     if (!fallbackName) {
@@ -110,6 +118,8 @@ export default function PlaceOfInterestMenuModal({
 
     addExtraPlaceOfInterest({
       code,
+      geoCode: s.code,
+      geoType: s.type,
       name: fallbackName,
       names: s.names,
       pos: s.pos,

--- a/frontend/src/components/map/PlaceOfInterestMenuModal.tsx
+++ b/frontend/src/components/map/PlaceOfInterestMenuModal.tsx
@@ -101,14 +101,6 @@ export default function PlaceOfInterestMenuModal({
   };
 
   const handleAddSuggestion = (s: PlaceOfInterestSuggestDTO) => {
-    console.log("Suggestion complète :", s);
-    console.log("uid :", s.uid);
-    console.log("code :", s.code);
-    console.log("type :", s.type);
-    console.log("name :", s.name);
-    console.log("default_name :", s.default_name);
-    console.log("pos :", s.pos);
-    console.log("names :", s.names);
     const code = `local-${s.type}-${s.uid}`;
     const fallbackName = s.name?.trim() || s.default_name?.trim();
     if (!fallbackName) {

--- a/frontend/src/features/geo/communesApi.ts
+++ b/frontend/src/features/geo/communesApi.ts
@@ -1,4 +1,5 @@
 import { apiFetch } from "@/shared/apiFetch";
+import { normalizeGeoLanguage } from "@/features/geo/geoLanguage";
 
 export type PlaceOfInterestSuggestType = "commune" | "district" | "canton";
 
@@ -6,7 +7,15 @@ export type PlaceOfInterestSuggestDTO = {
   uid: number;
   type: PlaceOfInterestSuggestType;
   code: string;
+  name?: string | null;
   default_name: string;
+  names?: {
+    fr?: string | null;
+    de?: string | null;
+    it?: string | null;
+    en?: string | null;
+    ro?: string | null;
+  };
   pos: [number, number]; // [lat, lon]
 };
 
@@ -17,10 +26,10 @@ export type PlaceOfInterestSuggestResponse = {
 };
 
 export const communesApi = {
-  suggest: (q: string, signal?: AbortSignal, limit = 50) =>
+  suggest: (q: string, lang: string, signal?: AbortSignal, limit = 50) =>
     apiFetch<PlaceOfInterestSuggestResponse>("geoSearch/suggest/public", {
       method: "GET",
       signal,
-      query: { q, limit },
+      query: { q, lang: normalizeGeoLanguage(lang), limit },
     }),
 };

--- a/frontend/src/features/geo/geoApi.ts
+++ b/frontend/src/features/geo/geoApi.ts
@@ -1,5 +1,6 @@
 // Types utilitaires pour manipuler des données GeoJSON + appel API geo/by_year
 import { apiFetch } from "@/shared/apiFetch";
+import { normalizeGeoLanguage } from "@/features/geo/geoLanguage";
 
 // Coordonnée [longitude, latitude]
 export type Position = [number, number];
@@ -93,7 +94,7 @@ export const PlaceOfInterestApi = {
     apiFetch<PlaceOfInterestMapDTO[]>("geo/placeOfInterest", {
       method: "GET",
       signal,
-      query: { lang },
+      query: { lang: normalizeGeoLanguage(lang) },
     }),
 };
 

--- a/frontend/src/features/geo/geoApi.ts
+++ b/frontend/src/features/geo/geoApi.ts
@@ -36,6 +36,12 @@ export type YearMeta = {
   districts?: number | null;
 };
 
+export type GeoFeatureProperties = {
+  uid: number;
+  code?: string;
+  name?: string;
+};
+
 // Regroupe toutes les couches géo pour une année
 export type GeoBundle = {
   year: YearMeta;
@@ -82,10 +88,16 @@ export const geoApi = {
     }),
 };
 
+export type PlaceOfInterestGeoType =
+  | "commune"
+  | "district"
+  | "canton";
+
 export type PlaceOfInterestMapDTO = {
   code: string;
   name: string;
   pos: [number, number];
+  geo_type: PlaceOfInterestGeoType;
 };
 
 // Client API pour récupérer la liste des villes affichées sur la carte.

--- a/frontend/src/features/geo/geoLanguage.ts
+++ b/frontend/src/features/geo/geoLanguage.ts
@@ -1,0 +1,11 @@
+export function normalizeGeoLanguage(
+  language?: string | null
+): string {
+  return (
+    language
+      ?.trim()
+      .toLowerCase()
+      .replace("_", "-")
+      .split("-")[0] || "en"
+  );
+}

--- a/frontend/src/features/geo/geoLanguage.ts
+++ b/frontend/src/features/geo/geoLanguage.ts
@@ -1,11 +1,18 @@
 export function normalizeGeoLanguage(
   language?: string | null
 ): string {
-  return (
+  const normalizedLanguage =
     language
       ?.trim()
       .toLowerCase()
       .replace("_", "-")
-      .split("-")[0] || "en"
-  );
+      .split("-")[0] || "en";
+
+  // Le frontend utilise "rm" pour le romanche,
+  // tandis que le backend utilise actuellement "ro".
+  if (normalizedLanguage === "rm") {
+    return "ro";
+  }
+
+  return normalizedLanguage;
 }

--- a/frontend/src/features/geo/hooks/usePlaceOfInterestMarkers.ts
+++ b/frontend/src/features/geo/hooks/usePlaceOfInterestMarkers.ts
@@ -2,11 +2,22 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import type { LatLngExpression } from "leaflet";
 import { useTranslation } from "react-i18next";
 import { PlaceOfInterestApi, PlaceOfInterestMapDTO } from "@/features/geo/geoApi";
+import { normalizeGeoLanguage } from "@/features/geo/geoLanguage";
+
+// Represente les noms localisés d'une ville dans différentes langues.
+export type LocalizedPlaceNames = {
+  fr?: string | null;
+  de?: string | null;
+  it?: string | null;
+  en?: string | null;
+  ro?: string | null;
+};
 
 // Représente une ville à afficher sur la carte.
 export type PlaceOfInterestMarker = {
   code: string;
   name: string;
+  names?: LocalizedPlaceNames;
   pos: LatLngExpression;
   source: "backend" | "local";
 };
@@ -36,6 +47,26 @@ const backendCacheByLang: Record<string, PlaceOfInterestMarker[]> = {};
 
 const LOCAL_PLACE_OF_INTEREST_STORAGE_KEY = "map_extra_place_of_interest";
 
+const isValidLocalizedPlaceNames = (
+  value: unknown
+): value is LocalizedPlaceNames => {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const names = value as Record<string, unknown>;
+
+  return ["fr", "de", "it", "en", "ro"].every((lang) => {
+    const name = names[lang];
+
+    return (
+      name === undefined ||
+      name === null ||
+      typeof name === "string"
+    );
+  });
+};
+
 const isValidLocalPlaceOfInterest = (value: unknown): value is PlaceOfInterestMarker => {
   if (!value || typeof value !== "object") return false;
 
@@ -46,6 +77,10 @@ const isValidLocalPlaceOfInterest = (value: unknown): value is PlaceOfInterestMa
     typeof item.code === "string" &&
     typeof item.name === "string" &&
     item.source === "local" &&
+    (
+      item.names === undefined ||
+      isValidLocalizedPlaceNames(item.names)
+    ) &&
     Array.isArray(pos) &&
     pos.length === 2 &&
     typeof pos[0] === "number" &&
@@ -90,6 +125,25 @@ const saveLocalPlaceOfInterest = (items: PlaceOfInterestMarker[]) => {
   }
 };
 
+const resolveLocalPlaceOfInterestName = (
+    placeOfInterest: PlaceOfInterestMarker,
+    lang: string
+  ): string => {
+    const localizedName =
+      placeOfInterest.names?.[
+        lang as keyof LocalizedPlaceNames
+      ];
+
+    if (
+      typeof localizedName === "string" &&
+      localizedName.trim()
+    ) {
+      return localizedName.trim();
+    }
+
+    return placeOfInterest.name;
+  };
+
 export function usePlaceOfInterestMarkers(lang: string): UsePlaceOfInterestMarkersResult {
   const { t } = useTranslation();
   const [backendPlaceOfInterest, setBackendPlaceOfInterest] = useState<PlaceOfInterestMarker[]>([]);
@@ -99,6 +153,7 @@ export function usePlaceOfInterestMarkers(lang: string): UsePlaceOfInterestMarke
 
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const normalizedLang = normalizeGeoLanguage(lang);
 
   const abortRef = useRef<AbortController | null>(null);
 
@@ -107,8 +162,7 @@ export function usePlaceOfInterestMarkers(lang: string): UsePlaceOfInterestMarke
   }, [extraPlaceOfInterest]);
 
   useEffect(() => {
-    const normLang = (lang || "en").toLowerCase();
-    const cached = backendCacheByLang[normLang];
+    const cached = backendCacheByLang[normalizedLang];
     if (cached) {
       setBackendPlaceOfInterest(cached);
       setError(null);
@@ -124,7 +178,7 @@ export function usePlaceOfInterestMarkers(lang: string): UsePlaceOfInterestMarke
     setError(null);
 
     PlaceOfInterestApi
-      .list(normLang, ctrl.signal)
+      .list(normalizedLang, ctrl.signal)
       .then((raw: PlaceOfInterestMapDTO[]) => {
         const markers: PlaceOfInterestMarker[] = raw.map((c) => ({
           code: c.code,
@@ -132,7 +186,7 @@ export function usePlaceOfInterestMarkers(lang: string): UsePlaceOfInterestMarke
           pos: c.pos,
           source: "backend",
         }));
-        backendCacheByLang[normLang] = markers;
+        backendCacheByLang[normalizedLang] = markers;
         setBackendPlaceOfInterest(markers);
       })
       .catch((e: any) => {
@@ -146,7 +200,7 @@ export function usePlaceOfInterestMarkers(lang: string): UsePlaceOfInterestMarke
     return () => {
       ctrl.abort();
     };
-  }, [lang]);
+  }, [normalizedLang, t]);
 
   // Masque / démasque une ville spécifique en fonction de son code.   
   const togglePlaceOfInterestHidden = (code: string) => {
@@ -173,6 +227,18 @@ export function usePlaceOfInterestMarkers(lang: string): UsePlaceOfInterestMarke
     setExtraPlaceOfInterest((prev) => prev.filter((c) => c.code !== code));
   };
 
+  const localizedExtraPlaceOfInterest = useMemo(
+    () =>
+      extraPlaceOfInterest.map((placeOfInterest) => ({
+        ...placeOfInterest,
+        name: resolveLocalPlaceOfInterestName(
+          placeOfInterest,
+          normalizedLang
+        ),
+      })),
+    [extraPlaceOfInterest, normalizedLang]
+  );
+
   // Liste finale des villes visibles enregistrer mais pas dans le stockage local
   const placeOfInterest = useMemo(() => {
     // Si le toggle global est OFF, on ne montre aucune ville (backend + locales)
@@ -180,11 +246,18 @@ export function usePlaceOfInterestMarkers(lang: string): UsePlaceOfInterestMarke
         return [];
     }
 
-    const visibleBackend = backendPlaceOfInterest.filter((c) => !hiddenCodes.has(c.code));
-    const visibleExtras  = extraPlaceOfInterest.filter((c) => !hiddenCodes.has(c.code));
+    const visibleBackend = backendPlaceOfInterest.filter(
+      (placeOfInterest) =>
+        !hiddenCodes.has(placeOfInterest.code)
+    );
+
+    const visibleExtras = localizedExtraPlaceOfInterest.filter(
+      (placeOfInterest) =>
+        !hiddenCodes.has(placeOfInterest.code)
+    );
 
     return [...visibleBackend, ...visibleExtras];
-  }, [backendPlaceOfInterest, extraPlaceOfInterest, hideAllBackend, hiddenCodes]);
+  }, [backendPlaceOfInterest, localizedExtraPlaceOfInterest, hideAllBackend, hiddenCodes]);
 
   return {
     placeOfInterest,
@@ -195,7 +268,7 @@ export function usePlaceOfInterestMarkers(lang: string): UsePlaceOfInterestMarke
     setHideAllBackend,
     hiddenCodes,
     togglePlaceOfInterestHidden,
-    extraPlaceOfInterest,
+    extraPlaceOfInterest:localizedExtraPlaceOfInterest,
     addExtraPlaceOfInterest,
     removeExtraPlaceOfInterest,
   };

--- a/frontend/src/features/geo/hooks/usePlaceOfInterestMarkers.ts
+++ b/frontend/src/features/geo/hooks/usePlaceOfInterestMarkers.ts
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { LatLngExpression } from "leaflet";
 import { useTranslation } from "react-i18next";
-import { PlaceOfInterestApi, PlaceOfInterestMapDTO } from "@/features/geo/geoApi";
+import { PlaceOfInterestApi, PlaceOfInterestMapDTO, PlaceOfInterestGeoType } from "@/features/geo/geoApi";
 import { normalizeGeoLanguage } from "@/features/geo/geoLanguage";
 
 // Represente les noms localisés d'une ville dans différentes langues.
@@ -16,6 +16,8 @@ export type LocalizedPlaceNames = {
 // Représente une ville à afficher sur la carte.
 export type PlaceOfInterestMarker = {
   code: string;
+  geoCode?: string;
+  geoType: PlaceOfInterestGeoType;
   name: string;
   names?: LocalizedPlaceNames;
   pos: LatLngExpression;
@@ -67,6 +69,13 @@ const isValidLocalizedPlaceNames = (
   });
 };
 
+const isValidGeoType = (
+  value: unknown
+): value is PlaceOfInterestGeoType =>
+  value === "commune" ||
+  value === "district" ||
+  value === "canton";
+
 const isValidLocalPlaceOfInterest = (value: unknown): value is PlaceOfInterestMarker => {
   if (!value || typeof value !== "object") return false;
 
@@ -77,6 +86,11 @@ const isValidLocalPlaceOfInterest = (value: unknown): value is PlaceOfInterestMa
     typeof item.code === "string" &&
     typeof item.name === "string" &&
     item.source === "local" &&
+    isValidGeoType(item.geoType) &&
+    (
+      item.geoCode === undefined ||
+      typeof item.geoCode === "string"
+    ) &&
     (
       item.names === undefined ||
       isValidLocalizedPlaceNames(item.names)
@@ -182,6 +196,8 @@ export function usePlaceOfInterestMarkers(lang: string): UsePlaceOfInterestMarke
       .then((raw: PlaceOfInterestMapDTO[]) => {
         const markers: PlaceOfInterestMarker[] = raw.map((c) => ({
           code: c.code,
+          geoCode: c.code,
+          geoType: c.geo_type,
           name: c.name,
           pos: c.pos,
           source: "backend",


### PR DESCRIPTION
### Objectif

Cette PR améliore l'affichage des lieux d'intérêt sur la carte en distinguant les différents niveaux géographiques.

L'objectif est de conserver l'affichage actuel des communes sous forme de marqueurs ponctuels tout en affichant les districts et les cantons directement à partir de leurs géométries respectives. Cette évolution permet une représentation plus cohérente des différents types de lieux d'intérêt sans modifier le fonctionnement existant de la gestion des POI.

---

### Changements principaux

#### Ajout du type géographique des lieux d'intérêt
- Ajout du champ `geo_type` dans les réponses de la route `GET /geo/placeOfInterest`.
- Distinction des trois types de lieux pris en charge :
  - `commune` ;
  - `district` ;
  - `canton`.
- Le backend détermine automatiquement le type géographique à partir du code du lieu.
- Conservation de la structure actuelle des réponses afin de limiter les impacts sur le frontend.

---

#### Mise à jour des schémas backend
- Ajout du champ `geo_type` dans le schéma `PlaceOfInterestClientOut`.
- Validation du type géographique par les modèles Pydantic.
- Conservation des autres champs existants (`code`, `name`, `pos`).

---

#### Mise à jour des types frontend
- Ajout du type `PlaceOfInterestGeoType`.
- Ajout du champ `geoType` dans les marqueurs utilisés par le frontend.
- Ajout du champ optionnel `geoCode` afin de conserver le véritable code géographique des lieux ajoutés localement.
- Conservation du champ `code` utilisé par le frontend pour la gestion des listes, du masquage et de la suppression.

---

#### Conservation du fonctionnement des lieux locaux
- Les lieux ajoutés localement continuent d'utiliser un identifiant interne de la forme :
  - `local-commune-...`
  - `local-district-...`
  - `local-canton-...`
- Ajout du véritable code géographique dans le champ `geoCode`.
- Aucune modification du fonctionnement du `localStorage`.
- Les fonctionnalités de masquage, suppression et persistance continuent de s'appuyer sur le champ `code`.

Exemple :

```json
{
  "code": "local-district-117",
  "geoCode": "B2227",
  "geoType": "district",
  "name": "Morges",
  "source": "local"
}
```

---

#### Affichage différencié des lieux d'intérêt
- Les communes continuent d'être affichées sous forme de marqueurs (`CircleMarker`).
- Les districts sont désormais affichés à partir de leur géométrie GeoJSON.
- Les cantons sont également affichés à partir de leur géométrie GeoJSON.
- Les tooltips restent disponibles sur l'ensemble des types de lieux d'intérêt.

---

#### Réutilisation des couches géographiques déjà chargées
- Réutilisation des couches `communes`, `districts` et `cantons` déjà récupérées par la carte.
- Aucun appel API supplémentaire n'est nécessaire.
- Les géométries sont retrouvées à partir de leur code géographique.

---

#### Intégration au thème graphique
- Les couleurs des districts et des cantons utilisent désormais les couleurs fournies par le thème.
- Suppression des couleurs codées en dur pour ces nouveaux affichages.
- Conservation du style actuel des marqueurs des communes.

---

#### Compatibilité avec les anciennes données locales
- Les anciens lieux enregistrés dans le `localStorage` restent compatibles.
- Lorsqu'un `geoCode` n'est pas disponible, un fallback permet de retrouver la géométrie à partir de l'identifiant local (`local-...`).
- Les anciennes données ne nécessitent donc pas d'être recréées.

---

#### Conservation du comportement existant
- Aucun changement du système de cache des lieux d'intérêt.
- Aucun changement du système de traduction.
- Aucun changement de la gestion des tooltips.
- Aucun changement du système de masquage ou de suppression des lieux.
- Aucun changement des appels API existants en dehors de l'ajout du champ `geo_type`.

---

### Limites actuelles

- Les communes restent volontairement représentées par un marqueur ponctuel.
- Les districts et les cantons utilisent uniquement le contour de leur géométrie sans remplissage.
- Les couleurs des contours dépendent du thème actuellement sélectionné.
- Si aucune géométrie n'est retrouvée pour un district ou un canton, le lieu est automatiquement affiché sous forme de marqueur afin de conserver un comportement robuste.

---

### Résultat

- Les communes continuent d'être affichées comme auparavant.
- Les districts sont désormais représentés directement par leur contour géographique.
- Les cantons sont également affichés à partir de leur géométrie.
- Les lieux locaux et les lieux provenant du backend utilisent le même mécanisme d'affichage.
- Les fonctionnalités existantes (cache, traduction, masquage, suppression et persistance) restent inchangées.
- L'affichage des lieux d'intérêt devient plus cohérent avec leur niveau géographique tout en limitant les modifications apportées à l'architecture existante.

---

### Images
<img width="1729" height="741" alt="Capture d’écran 2026-07-28 à 15 51 31" src="https://github.com/user-attachments/assets/a698b60f-982e-4a9a-921b-bab7596f55ac" />

