### PR TITLE
Fix #343 optimisation du rendue choropleth

### DIFF
--- a/backend/app/api/router/geo.py
+++ b/backend/app/api/router/geo.py
@@ -1,12 +1,18 @@
 from typing import Optional, Set
-
+import orjson
+from starlette.responses import Response
 
 from app.db import get_db
 from app.repositories.placeOfInterest_repo import list_placeOfInterest_for_lang
-from app.schemas.choropleth import ChoroplethGranularity, ChoroplethResponse
+from app.schemas.choropleth import (
+    ChoroplethGranularity,
+    ChoroplethGeometriesResponse,
+    ChoroplethResponse,
+    ChoroplethValuesResponse,
+)
 from app.schemas.geo import GeoBundle
 from app.schemas.placeOfInterest import PlaceOfInterestClientOut
-from app.services.choropleth_service import build_choropleth
+from app.services.choropleth_service import build_choropleth, build_choropleth_geometries, build_choropleth_values
 from app.services.comparison_service import build_area_comparison
 from app.services.geo_service import ALL_LAYERS, get_geo_by_year_selective
 from fastapi import APIRouter, Depends, Query
@@ -84,7 +90,7 @@ async def commune_choropleth(
         year=year,
         granularity=granularity,
     )
-    return ChoroplethResponse(
+    response = ChoroplethResponse(
         question_uid=question_uid,
         year_requested=year,
         granularity=granularity,
@@ -93,6 +99,60 @@ async def commune_choropleth(
         legend=legend,
         feature_collection=fc,
     )
+    _content = orjson.dumps(response.model_dump(mode="json"))
+    return Response(content=_content, media_type="application/json")
+
+
+@router.get("/choropleth/geometries", response_model=ChoroplethGeometriesResponse)
+async def choropleth_geometries(
+    year: int = Query(...),
+    granularity: ChoroplethGranularity = Query("commune"),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Return the geographic shapes for a given granularity and year,
+    with no dependency on survey answers.
+    """
+    fc, meta = await build_choropleth_geometries(db, year=year, granularity=granularity)
+    response = ChoroplethGeometriesResponse(
+        year_requested=year,
+        year_geo_districts=meta.get("districts"),
+        year_geo_cantons=meta.get("cantons"),
+        granularity=granularity,
+        feature_collection=fc,
+    )
+    _content = orjson.dumps(response.model_dump(mode="json"))
+    return Response(content=_content, media_type="application/json")
+
+
+@router.get("/choropleth/values", response_model=ChoroplethValuesResponse)
+async def choropleth_values(
+    scope: str = Query(..., pattern="^(per_survey|global)$"),
+    question_uid: int = Query(...),
+    year: int = Query(...),
+    granularity: ChoroplethGranularity = Query("commune"),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Return legend and per-unit values for a given question/year/granularity,
+    with no geometry payload.
+    """
+    legend, values, _meta = await build_choropleth_values(
+        db,
+        scope=scope,
+        question_uid=question_uid,
+        year=year,
+        granularity=granularity,
+    )
+    response = ChoroplethValuesResponse(
+        question_uid=question_uid,
+        year_requested=year,
+        granularity=granularity,
+        legend=legend,
+        values=values,
+    )
+    _content = orjson.dumps(response.model_dump(mode="json"))
+    return Response(content=_content, media_type="application/json")
 
 
 @router.get("/comparison")

--- a/backend/app/schemas/choropleth.py
+++ b/backend/app/schemas/choropleth.py
@@ -45,3 +45,30 @@ class ChoroplethResponse(BaseModel):
     granularity: ChoroplethGranularity
     legend: MapLegend
     feature_collection: FeatureCollection = Field(..., description="GeoJSON FeatureCollection des communes")
+
+
+class ChoroplethGeometriesResponse(BaseModel):
+    year_requested: int
+    year_geo_districts: Optional[int] = None
+    year_geo_cantons: Optional[int] = None
+    granularity: ChoroplethGranularity
+    feature_collection: FeatureCollection
+
+
+class ChoroplethValueEntry(BaseModel):
+    value: Optional[Any] = None
+    value_kind: str  # "value" | "no_data" | "no_response"
+    fill_color: str = "#cccccc"
+    fill_pattern: Optional[Any] = None
+    special_dominant: bool = False
+    top_real_count: int = 0
+    cnt_null: int = 0
+    cnt_empty: int = 0
+
+
+class ChoroplethValuesResponse(BaseModel):
+    question_uid: int
+    year_requested: int
+    granularity: ChoroplethGranularity
+    legend: MapLegend
+    values: dict[str, ChoroplethValueEntry]

--- a/backend/app/services/choropleth_service.py
+++ b/backend/app/services/choropleth_service.py
@@ -3,8 +3,7 @@
 # (par exemple des communes) sont colorées en fonction d'une valeur de données
 # (statistique, réponse à un sondage, score numérique, etc.).
 from typing import Any, List, Optional
-import json
-
+import orjson
 
 from app.models.answer import Answer
 from app.models.canton import Canton
@@ -17,7 +16,13 @@ from app.models.option import Option
 from app.models.question_option_association import QuestionOptionAssociation
 from app.models.question_per_survey import QuestionPerSurvey
 from app.models.survey import Survey
-from app.schemas.choropleth import ChoroplethGranularity, GradientMeta, LegendItem, MapLegend
+from app.schemas.choropleth import (
+    ChoroplethGranularity,
+    ChoroplethValueEntry,
+    GradientMeta,
+    LegendItem,
+    MapLegend,
+)
 from app.schemas.geo import Feature, FeatureCollection, Geometry
 from geoalchemy2 import functions as geofunc
 from sqlalchemy import and_, case, cast, func, Integer, Numeric, select
@@ -27,6 +32,7 @@ from sqlalchemy.sql.selectable import FromClause
 
 
 NO_DATA_COLOR = "#cccccc"  # gris
+_DUMMY_GEOM = Geometry(type="Point", coordinates=[0.0, 0.0])
 NO_RESPONSE_COLOR = "#f59e0b"  # orange/ambre
 GRAD_START = "#22c55e"  # vert
 GRAD_END = "#3b82f6"  # bleu
@@ -414,7 +420,7 @@ def _pick_aggregated_value(
 
 
 def _geojson_col(geom_col) -> ColumnElement:
-    return geofunc.ST_AsGeoJSON(geofunc.ST_Transform(geom_col, 4326), maxdecimaldigits=5)
+    return geofunc.ST_AsGeoJSON(geom_col, maxdecimaldigits=5)
 
 
 def _numeric_regex_col() -> ColumnElement:
@@ -700,7 +706,7 @@ def _rows_to_features(
         if r.get("geojson") is None:
             continue
 
-        gj = json.loads(r["geojson"])
+        gj = orjson.loads(r["geojson"])
 
         cnt_null = int(r.get("cnt_null") or 0)
         cnt_empty = int(r.get("cnt_empty") or 0)
@@ -828,31 +834,6 @@ async def build_choropleth(
             target_year=year,
             year_window=1,
         )
-
-        communes_requested = int((await db.execute(select(func.count()).select_from(commune_agg))).scalar_one() or 0)
-        communes_with_geo = int((await db.execute(select(func.count()).select_from(cm_best))).scalar_one() or 0)
-
-        if communes_requested == 0:
-            _add_warning(
-                years_meta,
-                code="NO_ANSWERS",
-                message=f"No answers for question_uid={q_uid} year={year} (commune).",
-                q_uid=q_uid,
-                year=year,
-                granularity="commune",
-            )
-            return _empty_return(years_meta)
-
-        if communes_with_geo == 0:
-            _add_warning(
-                years_meta,
-                code="NO_GEO_FOR_REQUESTED",
-                message=f"Answers exist but no commune geometry found in window +/-2 for question_uid={q_uid} year={year}.",
-                q_uid=q_uid,
-                year=year,
-                granularity="commune",
-            )
-            return _empty_return(years_meta)
 
         stmt = (
             select(
@@ -1051,7 +1032,7 @@ async def build_choropleth(
 
         feats: list[Feature] = []
         for r in rows:
-            gj = json.loads(r["geojson"])
+            gj = orjson.loads(r["geojson"])
             feats.append(
                 Feature(
                     geometry=Geometry(**gj),
@@ -1094,3 +1075,371 @@ async def build_choropleth(
         granularity=str(granularity),
     )
     return _empty_return(years_meta)
+
+
+def _all_commune_geo_cte(*, target_year: int, year_window: int = 1):
+    """
+    Like _best_commune_map_for_requested_cte_window but for ALL communes,
+    not filtered by which communes have answers.
+    """
+    y_min = target_year - year_window
+    y_max = target_year + year_window
+
+    cm_ranked = (
+        select(
+            CommuneMap.commune_uid.label("unit_uid"),
+            CommuneMap.geometry.label("geometry"),
+            CommuneMap.year.label("map_year"),
+            func.row_number()
+            .over(
+                partition_by=CommuneMap.commune_uid,
+                order_by=[
+                    func.abs(CommuneMap.year - target_year).asc(),
+                    case((CommuneMap.year <= target_year, 0), else_=1).asc(),
+                    CommuneMap.year.desc(),
+                ],
+            )
+            .label("rn"),
+        )
+        .select_from(CommuneMap)
+        .where(and_(CommuneMap.year >= y_min, CommuneMap.year <= y_max))
+    ).cte("cm_ranked_all_window")
+
+    return (
+        select(cm_ranked.c.unit_uid, cm_ranked.c.geometry, cm_ranked.c.map_year)
+        .where(cm_ranked.c.rn == 1)
+    ).cte("cm_best_all_window")
+
+
+def _rows_to_value_features(
+    *,
+    level: str,
+    rows: list[dict[str, Any]],
+    use_mode: bool,
+) -> list[Feature]:
+    """
+    Like _rows_to_features but without geojson parsing.
+    Uses _DUMMY_GEOM as placeholder — geometry is not included in /values responses.
+    """
+    feats: list[Feature] = []
+    for r in rows:
+        cnt_null = int(r.get("cnt_null") or 0)
+        cnt_empty = int(r.get("cnt_empty") or 0)
+        top_real_count = int(r.get("top_real_count") or 0)
+
+        kind, val = _pick_aggregated_value(
+            cnt_empty=cnt_empty,
+            cnt_null=cnt_null,
+            cnt_non_empty=int(r.get("cnt_non_empty") or 0),
+            cnt_num=int(r.get("cnt_num") or 0),
+            avg_num_int=r.get("avg_num_int"),
+            mode_text=r.get("mode_text"),
+            use_mode=use_mode,
+        )
+
+        props: dict[str, Any] = {
+            "level": level,
+            "unit_uid": int(r["uid"]),
+            "name": r["name"],
+            "code": r["code"],
+            "value_kind": kind,
+            "value": val,
+            "special_dominant": _special_dominates(cnt_null, cnt_empty, top_real_count),
+            "top_real_count": top_real_count,
+            "cnt_null": cnt_null,
+            "cnt_empty": cnt_empty,
+        }
+
+        if level != "commune":
+            tie_values = r.get("tie_values") or []
+            if not isinstance(tie_values, (list, tuple)):
+                tie_values = []
+
+            candidates_raw: list[tuple[str, Any]] = []
+            for tv in tie_values:
+                if tv is None:
+                    continue
+                candidates_raw.append(("value", str(tv)))
+
+            if top_real_count > 0:
+                if cnt_empty >= top_real_count:
+                    candidates_raw.append(("no_response", ""))
+                if cnt_null >= top_real_count:
+                    candidates_raw.append(("no_data", None))
+
+            candidates = _unique_keep_order(candidates_raw, limit=MAX_CATEGORIES)
+
+            if len(candidates) >= 2:
+                props["fill_pattern_candidates"] = [{"kind": k, "value": v} for (k, v) in candidates]
+                props["fill_pattern_opts"] = {"type": "stripes", "angle": 45, "stripe": 6}
+
+        feats.append(Feature(geometry=_DUMMY_GEOM, properties=props))
+
+    return feats
+
+
+def _features_to_values_dict(feats: list[Feature]) -> dict[str, ChoroplethValueEntry]:
+    result: dict[str, ChoroplethValueEntry] = {}
+    for f in feats:
+        uid_str = str(f.properties["unit_uid"])
+        result[uid_str] = ChoroplethValueEntry(
+            value=f.properties.get("value"),
+            value_kind=f.properties["value_kind"],
+            fill_color=f.properties.get("fill_color", NO_DATA_COLOR),
+            fill_pattern=f.properties.get("fill_pattern"),
+            special_dominant=bool(f.properties.get("special_dominant", False)),
+            top_real_count=int(f.properties.get("top_real_count", 0)),
+            cnt_null=int(f.properties.get("cnt_null", 0)),
+            cnt_empty=int(f.properties.get("cnt_empty", 0)),
+        )
+    return result
+
+
+async def build_choropleth_geometries(
+    db: "AsyncSession",
+    year: int,
+    granularity: "ChoroplethGranularity",
+) -> tuple["FeatureCollection", dict[str, Any]]:
+    """
+    Returns a FeatureCollection containing ALL geographic units for the given
+    granularity and year, with no answer/question dependency.
+    Also returns years_meta dict with keys 'communes', 'districts', 'cantons'.
+    """
+    years_meta: dict[str, Any] = {"communes": None, "districts": None, "cantons": None}
+
+    if granularity == "commune":
+        years_meta["communes"] = year
+        cm_best = _all_commune_geo_cte(target_year=year, year_window=1)
+        stmt = (
+            select(
+                Commune.uid.label("uid"),
+                Commune.name.label("name"),
+                Commune.code.label("code"),
+                cm_best.c.map_year.label("geo_year_used"),
+                _geojson_col(cm_best.c.geometry).label("geojson"),
+            )
+            .select_from(cm_best)
+            .join(Commune, Commune.uid == cm_best.c.unit_uid)
+        )
+        rows = (await db.execute(stmt)).mappings().all()
+        feats: list[Feature] = []
+        for r in rows:
+            if r.get("geojson") is None:
+                continue
+            gj = orjson.loads(r["geojson"])
+            feats.append(
+                Feature(
+                    geometry=Geometry(**gj),
+                    properties={
+                        "level": "commune",
+                        "unit_uid": int(r["uid"]),
+                        "name": r["name"],
+                        "code": r["code"],
+                        "geo_year_used": int(r["geo_year_used"]) if r.get("geo_year_used") is not None else None,
+                    },
+                )
+            )
+        return FeatureCollection(features=feats), years_meta
+
+    if granularity == "district":
+        y_geo = await _nearest_year_sql_window(db, DistrictMap, year, year_window=2)
+        years_meta["districts"] = y_geo
+        if y_geo is None:
+            return FeatureCollection(features=[]), years_meta
+        stmt = (
+            select(
+                District.uid.label("uid"),
+                District.name.label("name"),
+                District.code.label("code"),
+                _geojson_col(DistrictMap.geometry).label("geojson"),
+            )
+            .select_from(District)
+            .join(DistrictMap, and_(DistrictMap.district_id == District.uid, DistrictMap.year == y_geo))
+        )
+        rows = (await db.execute(stmt)).mappings().all()
+        feats = [
+            Feature(
+                geometry=Geometry(**orjson.loads(r["geojson"])),
+                properties={"level": "district", "unit_uid": int(r["uid"]), "name": r["name"], "code": r["code"]},
+            )
+            for r in rows
+            if r.get("geojson") is not None
+        ]
+        return FeatureCollection(features=feats), years_meta
+
+    if granularity in ("canton", "federal"):
+        y_geo = await _nearest_year_sql_window(db, CantonMap, year, year_window=2)
+        years_meta["cantons"] = y_geo
+        if y_geo is None:
+            return FeatureCollection(features=[]), years_meta
+        level = "canton" if granularity == "canton" else "federal"
+        stmt = (
+            select(
+                Canton.uid.label("uid"),
+                Canton.name.label("name"),
+                Canton.code.label("code"),
+                _geojson_col(CantonMap.geometry).label("geojson"),
+            )
+            .select_from(Canton)
+            .join(CantonMap, and_(CantonMap.canton_uid == Canton.uid, CantonMap.year == y_geo))
+        )
+        rows = (await db.execute(stmt)).mappings().all()
+        feats = [
+            Feature(
+                geometry=Geometry(**orjson.loads(r["geojson"])),
+                properties={"level": level, "unit_uid": int(r["uid"]), "name": r["name"], "code": r["code"]},
+            )
+            for r in rows
+            if r.get("geojson") is not None
+        ]
+        return FeatureCollection(features=feats), years_meta
+
+    return FeatureCollection(features=[]), years_meta
+
+
+async def build_choropleth_values(
+    db: "AsyncSession",
+    scope: str,
+    question_uid: int,
+    year: int,
+    granularity: "ChoroplethGranularity",
+) -> tuple["MapLegend", dict[str, "ChoroplethValueEntry"], dict[str, Any]]:
+    """
+    Returns (legend, values_dict, years_meta) without any geometry.
+    values_dict is keyed by str(unit_uid).
+    """
+    years_meta: dict[str, Any] = {"communes": None, "districts": None, "cantons": None}
+
+    smt = select(Option).join(QuestionOptionAssociation).where(QuestionOptionAssociation.question_uid == question_uid)
+    result = await db.scalars(smt)
+    options = result.all()
+
+    if scope == "global":
+        resolved = await _resolve_question_per_survey_uid_for_global(db, question_uid, year)
+        if resolved is None:
+            empty_legend = MapLegend(type="categorical", title="Responses", items=[LegendItem(label="No data", color=NO_DATA_COLOR, value=None)])
+            return empty_legend, {}, years_meta
+        q_uid = resolved
+    else:
+        q_uid = question_uid
+
+    distinct_cnt = await _global_distinct_non_empty_count(db, q_uid, year)
+    use_mode = distinct_cnt <= MAX_CATEGORIES
+
+    if granularity == "commune":
+        years_meta["communes"] = year
+        commune_agg = _commune_agg_cte(q_uid=q_uid, year=year)
+        stmt = (
+            select(
+                Commune.uid.label("uid"),
+                Commune.name.label("name"),
+                Commune.code.label("code"),
+                *_agg_cols(commune_agg),
+            )
+            .select_from(commune_agg)
+            .join(Commune, Commune.uid == commune_agg.c.gid)
+        )
+        rows = (await db.execute(stmt)).mappings().all()
+        feats = _rows_to_value_features(level="commune", rows=[dict(r) for r in rows], use_mode=use_mode)
+        if not feats:
+            empty_legend = MapLegend(type="categorical", title="Responses", items=[LegendItem(label="No data", color=NO_DATA_COLOR, value=None)])
+            return empty_legend, {}, years_meta
+        legend = _build_legend_and_colors(feats, options)
+        return legend, _features_to_values_dict(feats), years_meta
+
+    if granularity == "district":
+        y_geo = await _nearest_year_sql_window(db, DistrictMap, year, year_window=2)
+        years_meta["districts"] = y_geo
+        district_agg = _district_agg_cte(q_uid=q_uid, year=year)
+        # JOIN DistrictMap (existence only, no geometry selected) to match exactly
+        # the same set of units as the old choropleth — required for correct gradient vmin/vmax.
+        stmt = (
+            select(
+                District.uid.label("uid"),
+                District.name.label("name"),
+                District.code.label("code"),
+                *_agg_cols(district_agg),
+            )
+            .select_from(district_agg)
+            .join(District, District.uid == district_agg.c.gid)
+            .join(DistrictMap, and_(DistrictMap.district_id == District.uid, DistrictMap.year == y_geo))
+        )
+        rows = (await db.execute(stmt)).mappings().all()
+        feats = _rows_to_value_features(level="district", rows=[dict(r) for r in rows], use_mode=use_mode)
+        if not feats:
+            empty_legend = MapLegend(type="categorical", title="Responses", items=[LegendItem(label="No data", color=NO_DATA_COLOR, value=None)])
+            return empty_legend, {}, years_meta
+        legend = _build_legend_and_colors(feats, options)
+        return legend, _features_to_values_dict(feats), years_meta
+
+    if granularity == "canton":
+        y_geo = await _nearest_year_sql_window(db, CantonMap, year, year_window=2)
+        years_meta["cantons"] = y_geo
+        canton_agg = _canton_agg_cte(q_uid=q_uid, year=year)
+        # JOIN CantonMap (existence only, no geometry selected) to match exactly
+        # the same set of units as the old choropleth.
+        stmt = (
+            select(
+                Canton.uid.label("uid"),
+                Canton.name.label("name"),
+                Canton.code.label("code"),
+                *_agg_cols(canton_agg),
+            )
+            .select_from(canton_agg)
+            .join(Canton, Canton.uid == canton_agg.c.gid)
+            .join(CantonMap, and_(CantonMap.canton_uid == Canton.uid, CantonMap.year == y_geo))
+        )
+        rows = (await db.execute(stmt)).mappings().all()
+        feats = _rows_to_value_features(level="canton", rows=[dict(r) for r in rows], use_mode=use_mode)
+        if not feats:
+            empty_legend = MapLegend(type="categorical", title="Responses", items=[LegendItem(label="No data", color=NO_DATA_COLOR, value=None)])
+            return empty_legend, {}, years_meta
+        legend = _build_legend_and_colors(feats, options)
+        return legend, _features_to_values_dict(feats), years_meta
+
+    if granularity == "federal":
+        y_geo = await _nearest_year_sql_window(db, CantonMap, year, year_window=2)
+        years_meta["cantons"] = y_geo
+
+        total_rows = int(
+            (
+                await db.execute(
+                    select(func.count()).select_from(Answer).where(Answer.question_uid == q_uid, Answer.year == year)
+                )
+            ).scalar_one()
+            or 0
+        )
+        if total_rows == 0:
+            empty_legend = MapLegend(type="categorical", title="Responses", items=[LegendItem(label="No data", color=NO_DATA_COLOR, value=None)])
+            return empty_legend, {}, years_meta
+
+        global_kind, global_val = await _compute_global_value(db, q_uid, year, use_mode=use_mode)
+        special = await _global_special_stats(db, q_uid, year)
+
+        canton_rows = (await db.execute(select(Canton.uid, Canton.name, Canton.code))).mappings().all()
+        feats = [
+            Feature(
+                geometry=_DUMMY_GEOM,
+                properties={
+                    "level": "federal",
+                    "unit_uid": int(r["uid"]),
+                    "name": r["name"],
+                    "code": r["code"],
+                    "value_kind": global_kind,
+                    "value": global_val,
+                    "special_dominant": bool(special["special_dominant"]),
+                    "top_real_count": int(special["top_real_count"]),
+                    "cnt_null": int(special["cnt_null"]),
+                    "cnt_empty": int(special["cnt_empty"]),
+                },
+            )
+            for r in canton_rows
+        ]
+        if not feats:
+            empty_legend = MapLegend(type="categorical", title="Responses", items=[LegendItem(label="No data", color=NO_DATA_COLOR, value=None)])
+            return empty_legend, {}, years_meta
+        legend = _build_legend_and_colors(feats, options)
+        return legend, _features_to_values_dict(feats), years_meta
+
+    empty_legend = MapLegend(type="categorical", title="Responses", items=[])
+    return empty_legend, {}, years_meta

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -2,8 +2,11 @@ FROM python:3.12-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libexpat1 \
-    build-essential curl && \
-    rm -rf /var/lib/apt/lists/*
+    build-essential \
+    curl \
+    gdal-bin \
+    libgdal-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -2,11 +2,8 @@ FROM python:3.12-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libexpat1 \
-    build-essential \
-    curl \
-    gdal-bin \
-    libgdal-dev \
-    && rm -rf /var/lib/apt/lists/*
+    build-essential curl && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1

--- a/frontend/src/features/geo/choroplethGeometryCache.ts
+++ b/frontend/src/features/geo/choroplethGeometryCache.ts
@@ -1,0 +1,79 @@
+import { ChoroplethGranularity, ChoroplethGeometriesResponse } from "./geoApi";
+
+/**
+ * LRU budget-based cache for choropleth geometry responses.
+ *
+ * Weight per granularity (commune data is much heavier):
+ *   commune=5, district=2, canton=1, federal=1
+ * Maximum total budget: 12 (allows ~2 commune sets or many lighter ones).
+ */
+
+const GRANULARITY_WEIGHT: Record<ChoroplethGranularity, number> = {
+  commune: 5,
+  district: 2,
+  canton: 1,
+  federal: 1,
+};
+
+const MAX_BUDGET = 12;
+
+type CacheKey = `${number}:${ChoroplethGranularity}`;
+
+type CacheEntry = {
+  key: CacheKey;
+  data: ChoroplethGeometriesResponse;
+  weight: number;
+};
+
+const _order: CacheKey[] = [];
+const _store = new Map<CacheKey, CacheEntry>();
+
+function _makeKey(year: number, granularity: ChoroplethGranularity): CacheKey {
+  return `${year}:${granularity}`;
+}
+
+function _currentBudget(): number {
+  let total = 0;
+  for (const entry of _store.values()) total += entry.weight;
+  return total;
+}
+
+function _evictToFit(needed: number): void {
+  while (_order.length > 0 && _currentBudget() + needed > MAX_BUDGET) {
+    const lruKey = _order.shift()!;
+    _store.delete(lruKey);
+  }
+}
+
+export const choroplethGeometryCache = {
+  has(year: number, granularity: ChoroplethGranularity): boolean {
+    return _store.has(_makeKey(year, granularity));
+  },
+
+  get(year: number, granularity: ChoroplethGranularity): ChoroplethGeometriesResponse | undefined {
+    const key = _makeKey(year, granularity);
+    const entry = _store.get(key);
+    if (!entry) return undefined;
+    // Move to end (most recently used)
+    const idx = _order.indexOf(key);
+    if (idx !== -1) _order.splice(idx, 1);
+    _order.push(key);
+    return entry.data;
+  },
+
+  set(year: number, granularity: ChoroplethGranularity, data: ChoroplethGeometriesResponse): void {
+    const key = _makeKey(year, granularity);
+    const weight = GRANULARITY_WEIGHT[granularity];
+
+    // Remove existing entry for this key if present
+    if (_store.has(key)) {
+      const idx = _order.indexOf(key);
+      if (idx !== -1) _order.splice(idx, 1);
+      _store.delete(key);
+    }
+
+    _evictToFit(weight);
+    _store.set(key, { key, data, weight });
+    _order.push(key);
+  },
+};

--- a/frontend/src/features/geo/geoApi.ts
+++ b/frontend/src/features/geo/geoApi.ts
@@ -79,6 +79,39 @@ export const geoApi = {
         ...(params.granularity ? { granularity: params.granularity } : {}),
       },
     }),
+
+  getChoroplethGeometries: (
+    params: { year: number; granularity?: ChoroplethGranularity },
+    signal?: AbortSignal
+  ) =>
+    apiFetch<ChoroplethGeometriesResponse>("geo/choropleth/geometries", {
+      method: "GET",
+      signal,
+      query: {
+        year: params.year,
+        ...(params.granularity ? { granularity: params.granularity } : {}),
+      },
+    }),
+
+  getChoroplethValues: (
+    params: {
+      scope: "per_survey" | "global";
+      question_uid: number;
+      year: number;
+      granularity?: ChoroplethGranularity;
+    },
+    signal?: AbortSignal
+  ) =>
+    apiFetch<ChoroplethValuesResponse>("geo/choropleth/values", {
+      method: "GET",
+      signal,
+      query: {
+        scope: params.scope,
+        question_uid: params.question_uid,
+        year: params.year,
+        ...(params.granularity ? { granularity: params.granularity } : {}),
+      },
+    }),
 };
 
 export type PlaceOfInterestMapDTO = {
@@ -146,4 +179,39 @@ export type ChoroplethResponse = {
       colors?: string[];
     };
   }>;
+};
+
+export type ChoroplethGeometryFeatureProps = {
+  level: ChoroplethGranularity;
+  unit_uid: number;
+  name?: string;
+  code?: string;
+  geo_year_used?: number | null;
+};
+
+export type ChoroplethGeometriesResponse = {
+  year_requested: number;
+  year_geo_districts?: number | null;
+  year_geo_cantons?: number | null;
+  granularity: ChoroplethGranularity;
+  feature_collection: FeatureCollection<ChoroplethGeometryFeatureProps>;
+};
+
+export type ChoroplethValueEntry = {
+  value?: any | null;
+  value_kind: "value" | "no_data" | "no_response";
+  fill_color: string;
+  fill_pattern?: any | null;
+  special_dominant: boolean;
+  top_real_count: number;
+  cnt_null: number;
+  cnt_empty: number;
+};
+
+export type ChoroplethValuesResponse = {
+  question_uid: number;
+  year_requested: number;
+  granularity: ChoroplethGranularity;
+  legend: MapLegend;
+  values: Record<string, ChoroplethValueEntry>;
 };

--- a/frontend/src/features/geo/hooks/useChoropleth.ts
+++ b/frontend/src/features/geo/hooks/useChoropleth.ts
@@ -1,5 +1,12 @@
 import { useEffect, useMemo, useState } from "react";
-import { geoApi, ChoroplethResponse, ChoroplethGranularity } from "@/features/geo/geoApi";
+import {
+  geoApi,
+  ChoroplethGranularity,
+  ChoroplethGeometriesResponse,
+  ChoroplethValuesResponse,
+  ChoroplethResponse,
+} from "@/features/geo/geoApi";
+import { choroplethGeometryCache } from "@/features/geo/choroplethGeometryCache";
 
 type Params = {
   scope: "per_survey" | "global";
@@ -8,6 +15,85 @@ type Params = {
   bins?: number;
   granularity?: ChoroplethGranularity;
 };
+
+const NO_DATA_COLOR = "#cccccc";
+
+function mergeChoroplethGeometriesAndValues(
+  geometries: ChoroplethGeometriesResponse,
+  values: ChoroplethValuesResponse
+): ChoroplethResponse {
+  // No values at all → preserve old behavior: empty feature collection
+  if (Object.keys(values.values).length === 0) {
+    return {
+      question_uid: values.question_uid,
+      year_requested: values.year_requested,
+      year_geo_districts: geometries.year_geo_districts ?? null,
+      year_geo_cantons: geometries.year_geo_cantons ?? null,
+      granularity: values.granularity,
+      legend: values.legend,
+      feature_collection: { type: "FeatureCollection", features: [] },
+    };
+  }
+
+  const features = geometries.feature_collection.features.map((f) => {
+    const uid = String(f.properties.unit_uid);
+    const entry = values.values[uid];
+
+    if (entry) {
+      return {
+        ...f,
+        properties: {
+          level: f.properties.level,
+          unit_uid: f.properties.unit_uid,
+          name: f.properties.name,
+          code: f.properties.code,
+          geo_year_used: f.properties.geo_year_used,
+          value: entry.value ?? null,
+          value_kind: entry.value_kind,
+          fill_color: entry.fill_color,
+          fill_pattern: entry.fill_pattern ?? undefined,
+          special_dominant: entry.special_dominant,
+          top_real_count: entry.top_real_count,
+          cnt_null: entry.cnt_null,
+          cnt_empty: entry.cnt_empty,
+        },
+      };
+    }
+
+    // Unit has geometry but no answer data
+    return {
+      ...f,
+      properties: {
+        level: f.properties.level,
+        unit_uid: f.properties.unit_uid,
+        name: f.properties.name,
+        code: f.properties.code,
+        geo_year_used: f.properties.geo_year_used,
+        value: null,
+        value_kind: "no_data" as const,
+        fill_color: NO_DATA_COLOR,
+        fill_pattern: undefined,
+        special_dominant: false,
+        top_real_count: 0,
+        cnt_null: 0,
+        cnt_empty: 0,
+      },
+    };
+  });
+
+  return {
+    question_uid: values.question_uid,
+    year_requested: values.year_requested,
+    year_geo_districts: geometries.year_geo_districts ?? null,
+    year_geo_cantons: geometries.year_geo_cantons ?? null,
+    granularity: values.granularity,
+    legend: values.legend,
+    feature_collection: {
+      type: "FeatureCollection",
+      features,
+    },
+  };
+}
 
 export function useChoropleth(params: Params) {
   const [data, setData] = useState<ChoroplethResponse | null>(null);
@@ -30,26 +116,44 @@ export function useChoropleth(params: Params) {
     const ctrl = new AbortController();
     let alive = true;
 
+    const year = params.year as number;
+    const granularity = params.granularity ?? "commune";
+
     setLoading(true);
     setErrorKey(null);
 
-    geoApi.getChoropleth({
-        scope: params.scope,
-        question_uid: params.question_uid as number,
-        year: params.year as number,
-        granularity: params.granularity ?? "commune",
-       
-        }, ctrl.signal)
-      .then((res) => {
-        if (!alive) return;        
-        setData(res);
+    const cachedGeo = choroplethGeometryCache.get(year, granularity);
+
+    const fetchPromise = cachedGeo
+      ? // Cache hit: fetch only values
+        geoApi
+          .getChoroplethValues(
+            { scope: params.scope, question_uid: params.question_uid as number, year, granularity },
+            ctrl.signal
+          )
+          .then((values) => mergeChoroplethGeometriesAndValues(cachedGeo, values))
+      : // Cache miss: fetch geometry + values in parallel
+        Promise.all([
+          geoApi.getChoroplethGeometries({ year, granularity }, ctrl.signal),
+          geoApi.getChoroplethValues(
+            { scope: params.scope, question_uid: params.question_uid as number, year, granularity },
+            ctrl.signal
+          ),
+        ]).then(([geo, values]) => {
+          choroplethGeometryCache.set(year, granularity, geo);
+          return mergeChoroplethGeometriesAndValues(geo, values);
+        });
+
+    fetchPromise
+      .then((merged) => {
+        if (!alive) return;
+        setData(merged);
       })
       .catch((e: any) => {
         if (!alive) return;
         const name = e?.name || "";
         const msg = (e?.message || "").toLowerCase();
         if (name === "AbortError" || msg.includes("aborted") || msg.includes("canceled")) return;
-
         setErrorKey("map.errors.loadGeometry");
       })
       .finally(() => {
@@ -61,7 +165,7 @@ export function useChoropleth(params: Params) {
       alive = false;
       ctrl.abort();
     };
-  }, [enabled, params.question_uid, params.year, params.bins, params.granularity]);
+  }, [enabled, params.question_uid, params.year, params.bins, params.granularity, params.scope]);
 
   return { data, loading, errorKey };
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ tqdm==4.67.1
 # Web backend (API)
 fastapi==0.115.0
 uvicorn[standard]==0.30.6
+orjson==3.10.18
 
 # Database / ORM
 SQLAlchemy==2.0.34


### PR DESCRIPTION
### Objectif

Cette PR améliore les performances du chargement des cartes choroplèthes en séparant les géométries des données métier.

L'objectif est d'éviter le rechargement systématique des géométries lors d'un changement de question, de scope ou de réponse tout en conservant exactement le même rendu visuel et le même comportement fonctionnel.

---

### Changements principaux

#### Séparation des géométries et des données du choroplèthe
- Ajout d'une nouvelle route `GET /geo/choropleth/geometries` dédiée au chargement des géométries.
- Ajout d'une nouvelle route `GET /geo/choropleth/values` dédiée aux données du choroplèthe.
- Conservation de la route historique `GET /geo/choropleth` afin de préserver la compatibilité avec le fonctionnement existant.
- Séparation claire entre les données géographiques statiques et les données dépendantes de la question sélectionnée.

---

#### Optimisation du backend
- Factorisation de la logique de génération des géométries et des valeurs du choroplèthe.
- Réutilisation de la logique métier existante afin de garantir un comportement identique.
- La route des valeurs ne charge plus les géométries et ne génère plus de `FeatureCollection`.
- Réduction importante du volume de données retourné lors des changements de question.

---

#### Mise en cache des géométries côté frontend
- Ajout d'un cache mémoire dédié aux géométries des choroplèthes.
- Les géométries sont indexées par année et granularité.
- Réutilisation automatique des géométries déjà téléchargées.
- Mise en place d'une politique d'éviction de type LRU afin de limiter la consommation mémoire.

---

#### Nouveau fonctionnement du chargement des choroplèthes
- Lors du premier affichage d'une combinaison année / granularité :
  - récupération des géométries ;
  - récupération des valeurs ;
  - fusion des deux réponses côté frontend.
- Lors des affichages suivants pour une géométrie déjà présente dans le cache :
  - réutilisation des géométries en mémoire ;
  - téléchargement uniquement des nouvelles valeurs.
- Conservation du même format de données utilisé par les composants d'affichage.

---

#### Reconstruction du choroplèthe côté frontend
- Ajout d'une étape de fusion entre les géométries mises en cache et les valeurs retournées par le backend.
- Conservation des propriétés géographiques existantes.
- Application des valeurs, couleurs, motifs et métadonnées sur les géométries correspondantes.
- Gestion des unités ne possédant pas de réponse afin de conserver leur affichage avec le style approprié.

---

#### Optimisation de la sérialisation des réponses
- Remplacement de `JSONResponse` par `ORJSONResponse` pour les réponses du choroplèthe.
- Utilisation de `orjson.loads` pour le traitement des géométries GeoJSON.
- Réduction du temps de sérialisation et de désérialisation des réponses.
- Amélioration des performances du traitement des données géographiques côté backend.

---

#### Optimisation des traitements géographiques
- Suppression des transformations géométriques inutiles lors de la génération du choroplèthe.
- Simplification de certaines requêtes SQL afin de limiter les traitements effectués par PostGIS.
- Réduction du temps de génération des réponses avant leur envoi au frontend.

---

#### Amélioration des performances
- Réduction importante du volume de données échangé lors d'un changement de question.
- Suppression du rechargement des géométries lorsque celles-ci sont déjà disponibles dans le cache.
- Réduction significative du temps de génération côté backend pour les changements de question.
- Chargement quasi instantané des choroplèthes après le premier affichage d'une année et d'une granularité données.

---

#### Conservation du fonctionnement existant
- Aucun changement du rendu visuel des choroplèthes.
- Aucun changement des couleurs, motifs ou légendes.
- Aucun changement du comportement des différents scopes.
- Aucun changement du comportement des différentes granularités.
- Aucun changement du fonctionnement de la route historique `GET /geo/choropleth`.
- Aucun changement du chargement géographique général de la page d'accueil.

---

### Limites actuelles

- Le premier affichage d'une année et d'une granularité nécessite toujours le téléchargement complet des géométries.
- Les géométries sont conservées uniquement en mémoire et sont perdues lors du rechargement de la page.
- Le cache est limité par une politique LRU afin de maîtriser la consommation mémoire.
- Cette optimisation concerne uniquement le système de choroplèthe et n'impacte pas les autres couches géographiques de l'application.

---

### Résultat

- Les traitements backend nécessaires à la génération des choroplèthes sont plus rapides.
- Les géométries ne sont plus téléchargées à chaque changement de question.
- Les changements de question deviennent quasi instantanés une fois les géométries chargées.
- Le volume de données transféré est fortement réduit lors des mises à jour du choroplèthe.
- Le rendu visuel, les couleurs, les motifs et les légendes restent identiques au fonctionnement précédent.
- Le comportement des différents scopes et granularités est conservé.
- L'architecture est désormais mieux adaptée aux futures optimisations des couches géographiques.

---

### Images
aucune l'UI reste identique