### PR TITLE
Fix #347 : add the possibility to run docker without initialising db

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,11 @@ docker_empty:
 	@echo "✅  Services started"
 	$(COMPOSE) logs -f $(INIT_EMPTY_SERVICE) $(API_SERVICE) $(FRONT_SERVICE)
 
+docker_run:
+	$(COMPOSE) up -d --build $(DB_SERVICE) $(API_SERVICE)
+	$(COMPOSE) up -d --build $(FRONT_SERVICE)
+	@echo "✅  Services started"
+	$(COMPOSE) logs -f $(API_SERVICE) $(FRONT_SERVICE)
 
 # Stop the project's Docker services and delete the containers + volumes
 docker_clean:


### PR DESCRIPTION
This pr aims to add the possibility to launch the docker app without having to initilisatin database each time